### PR TITLE
feat(universal-chart): add service labels support

### DIFF
--- a/charts/universal-chart/README.md
+++ b/charts/universal-chart/README.md
@@ -156,8 +156,9 @@ elsewhere (TODO: add link here)
 | s3.s3bucketName | string | `""` | S3 bucket name (required). Must be globally unique and follow S3 naming rules. |
 | s3.versioning | string | `"Suspended"` | Versioning status. Set to "Enabled" to enable versioning, "Suspended" to suspend it. |
 | securityContext | object | `{}` |  |
-| service | object | `{"annotations":{},"port":3000,"type":"ClusterIP"}` | A "service" is basically a named port which follows a pod or pods; you should always use a service when networking in k8s. More information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/ |
+| service | object | `{"annotations":{},"labels":{},"port":3000,"type":"ClusterIP"}` | A "service" is basically a named port which follows a pod or pods; you should always use a service when networking in k8s. More information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/ |
 | service.annotations | object | `{}` | a map of annotations to define on the main Service resource |
+| service.labels | object | `{}` | a map of labels to define on the main Service resource |
 | service.port | int | `3000` | Defines the port the service listens upon. This is the *external* port exposed by the container, not necessarily the internal port inside the container.  It also doesn't have to be 80 or 443; an ingress (if used) will listen on a differnet port and communicate with the container on this service/port combination. more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports |
 | service.type | string | `"ClusterIP"` | Define the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types |
 | serviceAccount.annotations | object | `{}` |  |

--- a/charts/universal-chart/templates/service.yaml
+++ b/charts/universal-chart/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "universal-chart.fullname" . }}
   labels:
     {{- include "universal-chart.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/universal-chart/values.yaml
+++ b/charts/universal-chart/values.yaml
@@ -221,6 +221,12 @@ service:
   # more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   type: ClusterIP
   # @schema
+  # type: object
+  # additionalProperties: true
+  # @schema
+  # -- a map of labels to define on the main Service resource
+  labels: {}
+  # @schema
   # additionalProperties: true
   # @schema
   # -- a map of annotations to define on the main Service resource

--- a/tests/test_universal_chart.py
+++ b/tests/test_universal_chart.py
@@ -199,10 +199,10 @@ def test_deployment_annotations_renders_correctly(helm_runner) -> None:
     assert metadata["annotations"].get("reloader.stakater.com/auto") == "true"
 
 
-def test_service_annotations_render_on_primary_service_only(
+def test_service_annotations_and_labels_render_on_primary_service_only(
     helm_runner,
 ) -> None:
-    """Ensure service annotations apply only to the main app service."""
+    """Ensure service metadata applies only to the main app service."""
 
     rendered = render_chart(
         helm_runner,
@@ -214,7 +214,10 @@ def test_service_annotations_render_on_primary_service_only(
                     "teleport.dev/public-addr": (
                         "example-app.teleport.apps.herodevs.io"
                     ),
-                }
+                },
+                "labels": {
+                    "herodevs.com/teleport-access": "true",
+                },
             },
             "serviceMonitor": {"alternatePort": 9090},
         },
@@ -239,7 +242,15 @@ def test_service_annotations_render_on_primary_service_only(
         "teleport.dev/name": "example-app",
         "teleport.dev/public-addr": ("example-app.teleport.apps.herodevs.io"),
     }
+    assert (
+        main_service["metadata"]["labels"]["herodevs.com/teleport-access"]
+        == "true"
+    )
     assert "annotations" not in metrics_service["metadata"]
+    assert (
+        "herodevs.com/teleport-access"
+        not in metrics_service["metadata"]["labels"]
+    )
 
 
 def test_service_monitor_renders_when_enabled(helm_runner) -> None:


### PR DESCRIPTION
## Summary
- add `service.labels` support to the universal chart service template
- document the new values key in the chart README
- cover the new behavior in the universal chart unit tests

## Why
Teleport Kubernetes app discovery can scope discovery using Kubernetes Service labels. This adds the missing chart support needed for opt-in Teleport app discovery on lab apps.

## Validation
- `pre-commit run --files charts/universal-chart/values.yaml charts/universal-chart/templates/service.yaml charts/universal-chart/README.md tests/test_universal_chart.py`
- `/home/sauer/dev/herodevs/helm-charts/.venv/bin/pytest tests/test_universal_chart.py -q`