### PR TITLE
fix(ingress-nginx): update image tag to v1.15.1-nes-1.15.2

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.15.1-ingress-nginx-1.15.2
+appVersion: v1.15.1-nes-1.15.2
 description: Never Ending Support ingress-nginx controller for Kubernetes using
   NGINX as a reverse proxy and load balancer
 home: https://github.com/neverendingsupport/ingress-nginx-nes

--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -2,7 +2,7 @@
 
 [ingress-nginx-nes](https://github.com/neverendingsupport/ingress-nginx-nes) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 
-![Version: 4.15.1-ingress-nginx-4.15.2](https://img.shields.io/badge/Version-4.15.1--ingress--nginx--4.15.2-informational?style=flat-square) ![AppVersion: v1.15.1-ingress-nginx-1.15.2](https://img.shields.io/badge/AppVersion-v1.15.1--ingress--nginx--1.15.2-informational?style=flat-square)
+![Version: 4.15.1-ingress-nginx-4.15.2](https://img.shields.io/badge/Version-4.15.1--ingress--nginx--4.15.2-informational?style=flat-square) ![AppVersion: v1.15.1-nes-1.15.2](https://img.shields.io/badge/AppVersion-v1.15.1--ingress--nginx--1.15.2-informational?style=flat-square)
 
 To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
@@ -27,7 +27,7 @@ helm install [RELEASE_NAME] oci://ghcr.io/neverendingsupport/charts/ingress-ngin
 ```
 
 The command deploys ingress-nginx on the Kubernetes cluster in the default configuration.
-By default, the chart installs `registry.nes.herodevs.com/neverendingsupport/ingress-nginx-controller:v1.15.1-ingress-nginx-1.15.2`.
+By default, the chart installs `registry.nes.herodevs.com/neverendingsupport/ingress-nginx-controller:v1.15.1-nes-1.15.2`.
 
 _See [configuration](#configuration) below._
 
@@ -358,7 +358,7 @@ metadata:
 | controller.image.runAsNonRoot | bool | `true` |  |
 | controller.image.runAsUser | int | `101` | This value must not be changed using the official image. uid=101(www-data) gid=82(www-data) groups=82(www-data) |
 | controller.image.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| controller.image.tag | string | `"v1.15.1-ingress-nginx-1.15.2"` |  |
+| controller.image.tag | string | `"v1.15.1-nes-1.15.2"` |  |
 | controller.ingressClass | string | `"nginx"` | For backwards compatibility with ingress.class annotation, use ingressClass. Algorithm is as follows, first ingressClassName is considered, if not present, controller looks for ingress.class annotation |
 | controller.ingressClassByName | bool | `false` | Process IngressClass per name (additionally as per spec.controller). |
 | controller.ingressClassResource | object | `{"aliases":[],"annotations":{},"controllerValue":"k8s.io/ingress-nginx","default":false,"enabled":true,"name":"nginx","parameters":{}}` | This section refers to the creation of the IngressClass resource. IngressClasses are immutable and cannot be changed after creation. We do not support namespaced IngressClasses, yet, so a ClusterRole and a ClusterRoleBinding is required. |

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -30,7 +30,7 @@ controller:
     ## for backwards compatibility consider setting the full image url via the repository value below
     ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
     ## repository:
-    tag: "v1.15.1-ingress-nginx-1.15.2"
+    tag: "v1.15.1-nes-1.15.2"
     digest: ""
     digestChroot: ""
     pullPolicy: IfNotPresent

--- a/tests/fixtures/ingress-nginx/minimal-values.golden.yaml
+++ b/tests/fixtures/ingress-nginx/minimal-values.golden.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -23,7 +23,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -39,7 +39,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx
@@ -123,7 +123,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx
@@ -144,7 +144,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -238,7 +238,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -261,7 +261,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -288,7 +288,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -323,7 +323,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -344,7 +344,7 @@ spec:
         helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+        app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: controller
@@ -352,7 +352,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
-          image: registry.nes.herodevs.com/neverendingsupport/ingress-nginx-controller:v1.15.1-ingress-nginx-1.15.2
+          image: registry.nes.herodevs.com/neverendingsupport/ingress-nginx-controller:v1.15.1-nes-1.15.2
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -449,7 +449,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -472,7 +472,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -514,7 +514,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -532,7 +532,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -557,7 +557,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -583,7 +583,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -609,7 +609,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -635,7 +635,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -648,7 +648,7 @@ spec:
         helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+        app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
@@ -697,7 +697,7 @@ metadata:
     helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+    app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -710,7 +710,7 @@ spec:
         helm.sh/chart: ingress-nginx-4.15.1-ingress-nginx-4.15.2
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/version: "v1.15.1-ingress-nginx-1.15.2"
+        app.kubernetes.io/version: "v1.15.1-nes-1.15.2"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook


### PR DESCRIPTION
Updates the controller image tag from `1.15.1-ingress-nginx-1.15.2` to `1.15.1-nes-1.15.2` in both `Values.yaml` and `\Chart.yaml` to match the published image tag convention.