### PR TITLE
feat: support rule labels (enables custom receivers)

### DIFF
--- a/charts/universal-chart/README.md
+++ b/charts/universal-chart/README.md
@@ -94,7 +94,8 @@ elsewhere (TODO: add link here)
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Select roughly specific nodes to run upon. This is similar to node selectors, but allows a bit more fuzziness and flexibility. More info at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity |
-| autoscaling | object | `{"enabled":false,"maxReplicas":10,"minReplicas":1,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null}` | section for configuring autoscaling. More information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/ |
+| autoscaling | object | `{"annotations":{},"enabled":false,"maxReplicas":10,"minReplicas":1,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null}` | section for configuring autoscaling. More information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/ |
+| autoscaling.annotations | object | `{}` | Additional annotations to add to the HorizontalPodAutoscaler metadata. |
 | autoscaling.enabled | bool | `false` | enable autoscaling |
 | autoscaling.maxReplicas | int | `10` | maximum number of replicas to run |
 | autoscaling.minReplicas | int | `1` | miminum number of replicas to run |
@@ -132,9 +133,10 @@ elsewhere (TODO: add link here)
 | podAnnotations | object | `{}` | Add additional annotations to the pod. Annotations are generally for "people" uses and interoperability. For more information check out: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
 | podLabels | object | `{}` | Add additional labels to the pods. Labels are generally for k8s internal use (pod selectors, etc) For more information check out: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ |
 | podSecurityContext | object | `{}` |  |
-| prometheusRule | object | `{"additionalLabels":{},"annotations":{},"enabled":false,"groups":[],"rules":[]}` | Configure a PrometheusRule for evaluating alerting rules against scraped metrics. |
+| prometheusRule | object | `{"additionalLabels":{},"annotations":{},"defaultRuleLabels":{},"enabled":false,"groups":[],"rules":[]}` | Configure a PrometheusRule for evaluating alerting rules against scraped metrics. |
 | prometheusRule.additionalLabels | object | `{}` | Additional labels to add to the PrometheusRule metadata. |
 | prometheusRule.annotations | object | `{}` | Additional annotations to add to the PrometheusRule metadata. |
+| prometheusRule.defaultRuleLabels | object | `{}` | Default labels to add to every alert rule. Per-rule labels override these defaults on conflicts. |
 | prometheusRule.enabled | bool | `false` | Whether to create a PrometheusRule resource. |
 | prometheusRule.groups | list | `[]` | Advanced path: full Prometheus rule groups. When set, this takes precedence over prometheusRule.rules. |
 | prometheusRule.rules | list | `[]` | Simple path: list of alerting rules rendered into a single default group. |

--- a/charts/universal-chart/templates/prometheusrule.yaml
+++ b/charts/universal-chart/templates/prometheusrule.yaml
@@ -14,11 +14,38 @@ metadata:
   {{- end }}
 spec:
   groups:
+    {{- $defaultRuleLabels := .Values.prometheusRule.defaultRuleLabels | default dict }}
     {{- if .Values.prometheusRule.groups }}
-    {{- toYaml .Values.prometheusRule.groups | nindent 4 }}
+    {{- range .Values.prometheusRule.groups }}
+    {{- $group := deepCopy . }}
+    {{- $renderedRules := list }}
+    {{- range .rules }}
+    {{- $rule := deepCopy . }}
+    {{- $mergedLabels := mergeOverwrite (deepCopy $defaultRuleLabels) (default dict .labels) }}
+    {{- if gt (len $mergedLabels) 0 }}
+    {{- $_ := set $rule "labels" $mergedLabels }}
+    {{- else }}
+    {{- $_ := unset $rule "labels" }}
+    {{- end }}
+    {{- $renderedRules = append $renderedRules $rule }}
+    {{- end }}
+    {{- $_ := set $group "rules" $renderedRules }}
+    {{- toYaml (list $group) | nindent 4 }}
+    {{- end }}
     {{- else }}
     - name: {{ include "universal-chart.fullname" . }}
       rules:
-        {{- toYaml .Values.prometheusRule.rules | nindent 8 }}
+        {{- $renderedRules := list }}
+        {{- range .Values.prometheusRule.rules }}
+        {{- $rule := deepCopy . }}
+        {{- $mergedLabels := mergeOverwrite (deepCopy $defaultRuleLabels) (default dict .labels) }}
+        {{- if gt (len $mergedLabels) 0 }}
+        {{- $_ := set $rule "labels" $mergedLabels }}
+        {{- else }}
+        {{- $_ := unset $rule "labels" }}
+        {{- end }}
+        {{- $renderedRules = append $renderedRules $rule }}
+        {{- end }}
+        {{- toYaml $renderedRules | nindent 8 }}
     {{- end }}
 {{- end }}

--- a/charts/universal-chart/values.schema.json
+++ b/charts/universal-chart/values.schema.json
@@ -121,6 +121,12 @@
             "type": "string"
           }
         },
+        "defaultRuleLabels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "groups": {
           "type": "array",
           "items": {

--- a/charts/universal-chart/values.yaml
+++ b/charts/universal-chart/values.yaml
@@ -284,6 +284,10 @@ serviceMonitor:
 #     type: object
 #     additionalProperties:
 #       type: string
+#   defaultRuleLabels:
+#     type: object
+#     additionalProperties:
+#       type: string
 #   groups:
 #     type: array
 #     items:
@@ -364,6 +368,12 @@ prometheusRule:
   # @schema
   # -- Additional annotations to add to the PrometheusRule metadata.
   annotations: {}
+  # @schema
+  # additionalProperties:
+  #   type: string
+  # @schema
+  # -- Default labels to add to every alert rule. Per-rule labels override these defaults on conflicts.
+  defaultRuleLabels: {}
   # -- Advanced path: full Prometheus rule groups. When set, this takes precedence over prometheusRule.rules.
   groups: []
   # -- Simple path: list of alerting rules rendered into a single default group.

--- a/tests/fixtures/universal-chart/prometheusrule-values.golden.yaml
+++ b/tests/fixtures/universal-chart/prometheusrule-values.golden.yaml
@@ -104,3 +104,5 @@ spec:
           for: 2m
           labels:
             severity: warning
+            slack_channel: '#alert-example'
+            team: example

--- a/tests/fixtures/universal-chart/prometheusrule-values.yaml
+++ b/tests/fixtures/universal-chart/prometheusrule-values.yaml
@@ -7,6 +7,9 @@ prometheusRule:
     example.com/source: chart
   additionalLabels:
     team: example
+  defaultRuleLabels:
+    slack_channel: "#alert-example"
+    team: example
   rules:
     - alert: ApplicationDown
       expr: up{job="universal-chart"} == 0

--- a/tests/test_universal_chart.py
+++ b/tests/test_universal_chart.py
@@ -76,6 +76,10 @@ def test_prometheus_rule_renders_rule_strings_verbatim(
                 "enabled": True,
                 "annotations": {"example.com/source": "chart"},
                 "additionalLabels": {"team": "example"},
+                "defaultRuleLabels": {
+                    "slack_channel": "#alert-example",
+                    "team": "example",
+                },
                 "rules": [
                     {
                         "alert": "ApplicationDown",
@@ -101,6 +105,9 @@ def test_prometheus_rule_renders_rule_strings_verbatim(
     assert prom_rule["metadata"]["annotations"]["example.com/source"] == "chart"
     rule = prom_rule["spec"]["groups"][0]["rules"][0]
     assert rule["expr"] == 'up{job="universal-chart"} == 0'
+    assert rule["labels"]["severity"] == "warning"
+    assert rule["labels"]["slack_channel"] == "#alert-example"
+    assert rule["labels"]["team"] == "example"
     assert rule["annotations"]["summary"] == "App {{ $labels.job }} down"
 
 
@@ -147,6 +154,51 @@ def test_prometheus_rule_supports_explicit_groups(helm_runner) -> None:
     assert group["interval"] == "1m"
     assert group["rules"][0]["alert"] == "ApplicationDown"
     assert group["rules"][0]["expr"] == 'up{job="eol-api"} == 0'
+
+
+def test_prometheus_rule_merges_default_labels_into_groups(helm_runner) -> None:
+    """Validate defaultRuleLabels applied to groups and per-rule labels win."""
+
+    rendered = render_chart(
+        helm_runner,
+        CHART,
+        values={
+            "prometheusRule": {
+                "enabled": True,
+                "defaultRuleLabels": {
+                    "application": "eol-api",
+                    "group": "eol",
+                    "slack_channel": "#alert-eol",
+                    "team": "data-integrations",
+                },
+                "groups": [
+                    {
+                        "name": "eol-api.rules",
+                        "rules": [
+                            {
+                                "alert": "ApplicationDown",
+                                "expr": 'up{job="eol-api"} == 0',
+                                "labels": {
+                                    "severity": "warning",
+                                    "slack_channel": "#alert-special",
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        },
+    )
+    manifests = load_manifests(rendered)
+    rule = get_manifest(manifests, "PrometheusRule")["spec"]["groups"][0][
+        "rules"
+    ][0]
+
+    assert rule["labels"]["application"] == "eol-api"
+    assert rule["labels"]["group"] == "eol"
+    assert rule["labels"]["team"] == "data-integrations"
+    assert rule["labels"]["severity"] == "warning"
+    assert rule["labels"]["slack_channel"] == "#alert-special"
 
 
 def test_resources_include_requests_for_cpu_and_memory(helm_runner) -> None:


### PR DESCRIPTION
## Summary

- add first-class `prometheusRule.defaultRuleLabels` support to `universal-chart`
- support both `prometheusRule.rules` and `prometheusRule.groups` while merging chart-wide default labels into each alert rule
- update schema, README, fixtures, and focused tests for the new PrometheusRule behavior
