### PR TITLE
fix(ingress-nginx): correct controller image path to nes/ingress-nginx (chart 0.0.3)

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -14,4 +14,4 @@ name: ingress-nginx
 sources:
 - https://github.com/neverendingsupport/ingress-nginx-nes
 - https://github.com/kubernetes/ingress-nginx
-version: 4.15.1-ingress-nginx-4.15.3
+version: 0.0.3

--- a/charts/ingress-nginx/README.md
+++ b/charts/ingress-nginx/README.md
@@ -27,7 +27,7 @@ helm install [RELEASE_NAME] oci://ghcr.io/neverendingsupport/charts/ingress-ngin
 ```
 
 The command deploys ingress-nginx on the Kubernetes cluster in the default configuration.
-By default, the chart installs `registry.nes.herodevs.com/neverendingsupport/ingress-nginx-controller:v1.15.1-ingress-nginx-1.15.2`.
+By default, the chart installs `registry.nes.herodevs.com/nes/ingress-nginx:v1.15.1-ingress-nginx-1.15.2`.
 
 _See [configuration](#configuration) below._
 
@@ -351,7 +351,7 @@ metadata:
 | controller.image.chroot | bool | `false` |  |
 | controller.image.digest | string | `""` |  |
 | controller.image.digestChroot | string | `""` |  |
-| controller.image.image | string | `"neverendingsupport/ingress-nginx-controller"` |  |
+| controller.image.image | string | `"nes/ingress-nginx"` |  |
 | controller.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.image.readOnlyRootFilesystem | bool | `false` |  |
 | controller.image.runAsGroup | int | `82` | This value must not be changed using the official image. uid=101(www-data) gid=82(www-data) groups=82(www-data) |

--- a/charts/ingress-nginx/README.md.gotmpl
+++ b/charts/ingress-nginx/README.md.gotmpl
@@ -24,7 +24,7 @@ helm install [RELEASE_NAME] oci://ghcr.io/neverendingsupport/charts/ingress-ngin
 ```
 
 The command deploys ingress-nginx on the Kubernetes cluster in the default configuration.
-By default, the chart installs `registry.nes.herodevs.com/neverendingsupport/ingress-nginx-controller:{{ template "chart.appVersion" . }}`.
+By default, the chart installs `registry.nes.herodevs.com/nes/ingress-nginx:{{ template "chart.appVersion" . }}`.
 
 _See [configuration](#configuration) below._
 

--- a/charts/ingress-nginx/tests/controller-daemonset_test.yaml
+++ b/charts/ingress-nginx/tests/controller-daemonset_test.yaml
@@ -175,7 +175,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: custom.registry.io/neverendingsupport/ingress-nginx-controller:v1.0.0-dev@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
+          value: custom.registry.io/nes/ingress-nginx:v1.0.0-dev@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
 
   - it: should create a DaemonSet with a custom registry if `controller.image.registry` is set
     set:
@@ -186,7 +186,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: custom.registry.io/neverendingsupport/ingress-nginx-controller:v1.0.0-dev@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
+          value: custom.registry.io/nes/ingress-nginx:v1.0.0-dev@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
 
   - it: should create a DaemonSet with a custom image if `controller.image.image` is set
     set:
@@ -207,7 +207,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry.nes.herodevs.com/neverendingsupport/ingress-nginx-controller:custom-tag@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
+          value: registry.nes.herodevs.com/nes/ingress-nginx:custom-tag@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
 
   - it: should create a DaemonSet with token auto-mounting disabled if `serviceAccount.automountServiceAccountToken` is false
     set:

--- a/charts/ingress-nginx/tests/controller-deployment_test.yaml
+++ b/charts/ingress-nginx/tests/controller-deployment_test.yaml
@@ -194,7 +194,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: custom.registry.io/neverendingsupport/ingress-nginx-controller:v1.0.0-dev@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
+          value: custom.registry.io/nes/ingress-nginx:v1.0.0-dev@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
 
   - it: should create a Deployment with a custom registry if `controller.image.registry` is set
     set:
@@ -204,7 +204,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: custom.registry.io/neverendingsupport/ingress-nginx-controller:v1.0.0-dev@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
+          value: custom.registry.io/nes/ingress-nginx:v1.0.0-dev@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
 
   - it: should create a Deployment with a custom image if `controller.image.image` is set
     set:
@@ -223,7 +223,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry.nes.herodevs.com/neverendingsupport/ingress-nginx-controller:custom-tag@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
+          value: registry.nes.herodevs.com/nes/ingress-nginx:custom-tag@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
 
   - it: should create a Deployment with `progressDeadlineSeconds` if `controller.progressDeadlineSeconds` is set
     set:

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -26,7 +26,7 @@ controller:
     ## Keep false as default for now!
     chroot: false
     registry: ""
-    image: neverendingsupport/ingress-nginx-controller
+    image: nes/ingress-nginx
     ## for backwards compatibility consider setting the full image url via the repository value below
     ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
     ## repository:


### PR DESCRIPTION
Republishes `ingress-nginx` chart `0.0.3` with the correct controller image path so installs actually pull a working image.

## Problem

Chart `0.0.3` (release `4.15.1-ingress-nginx-4.15.3`, merged in #119) shipped with::

    controller:
      image:
        image: neverendingsupport/ingress-nginx-controller

But the controller image is published at `registry.nes.herodevs.com/nes/ingress-nginx`. Anyone pulling this chart today gets a 404 on the image.

Verified via `docker pull` from WSL:
- ❌ `registry.nes.herodevs.com/neverendingsupport/ingress-nginx-controller:v1.15.1-nes-1.15.3` — not found
- ✅ `registry.nes.herodevs.com/nes/ingress-nginx:v1.15.1-nes-1.15.3` — pulls cleanly

## Fix

* `charts/ingress-nginx/values.yaml` — `controller.image.image: nes/ingress-nginx`
* `charts/ingress-nginx/Chart.yaml` — `version: 0.0.3` (aligned with the chart-releaser tag; was inadvertently `4.15.1-ingress-nginx-4.15.3` from upstream sync)
* `charts/ingress-nginx/README.md` + `README.md.gotmpl` — install reference and values table
* `charts/ingress-nginx/tests/controller-deployment_test.yaml` + `controller-daemonset_test.yaml` — helm-unittest fixtures expect the corrected path

## Coordination

Source repo (`neverendingsupport/ingress-nginx-nes`):
- PR #43 — same image-path fix in source chart (already updated)
- PR #44 — Go 1.26.3 toolchain bump + govulncheck CVE scanner

Once both source PRs merge to `devel`, the maintainer will re-tag `v1.15.1-nes-1.15.3` in place to also pick up the Go fix; this is safe because no consumers have pulled the broken-path chart yet. To republish chart `0.0.3`, the existing chart release / tag in this repo will need to be removed first (`release.yml` uses `cr upload --skip-existing`).

## Verification
- helm-unittest assertions updated to expect `nes/ingress-nginx` paths
- Image pullability verified via `docker pull` in WSL