### PR TITLE
chore(ingress-nginx): catch up Chart.yaml baseline to 0.0.5

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -14,4 +14,4 @@ name: ingress-nginx
 sources:
 - https://github.com/neverendingsupport/ingress-nginx-nes
 - https://github.com/kubernetes/ingress-nginx
-version: 0.0.3
+version: 0.0.5


### PR DESCRIPTION
The source-of-truth `Chart.yaml` on main lagged behind the published artifacts. Chart versions `0.0.4` and `0.0.5` were republished via the release workflow's manual dispatch (per the ingress-nginx-nes PR #40 post-mortem) without writing the bumped version back to this repo.

Setting `Chart.yaml` to `0.0.5` here so the next bump (to `0.0.6` in PR #129) reads as the +1 step it actually is, instead of `0.0.3` -> `0.0.6`.

`appVersion` left untouched at `v1.15.1-nes-1.15.3`; PR #129 advances it to `v1.15.1-nes-1.15.4`.

## Sequence

1. Merge this PR first (no chart artifact change -- just metadata catch-up)
2. PR #129's diff auto-recomputes to `0.0.5` -> `0.0.6`
3. Merge PR #129, the release workflow publishes `0.0.6`