### PR TITLE
feat(universal-chart)!: block public metrics ingress by default #major

### DIFF
--- a/charts/universal-chart/README.md
+++ b/charts/universal-chart/README.md
@@ -83,6 +83,66 @@ Of note: the ingress configuration always goes in the Argo Application, not in
 your values YAML. An explanation of how Argo Applications work is documented
 elsewhere (TODO: add link here)
 
+## Public Metrics Blocking
+
+When both `ingress.enabled` and `serviceMonitor.enabled` are true, this chart
+creates an additional ingress-nginx Ingress that denies public access to the
+metrics path. The default block path is `serviceMonitor.path`; if that value is
+null, the block path defaults to `/metrics` to match Prometheus' default scrape
+path.
+
+The blocking Ingress renders only for ingress classes listed in
+`serviceMonitor.blockExternalIngress.ingressClassNames`, which defaults to
+`["", "nginx"]`. Include `""` for classless Ingresses handled by a default
+ingress-nginx controller. If your ingress-nginx controller uses another class
+name, add it explicitly:
+
+```yaml
+serviceMonitor:
+  blockExternalIngress:
+    ingressClassNames:
+      - ""
+      - nginx
+      - nginx-internal
+```
+
+The chart fails to render instead of silently leaving metrics public when the
+configured Ingress class is not known to be ingress-nginx, when the primary
+Ingress uses nginx regex or rewrite annotations, or when the primary Ingress
+already declares the metrics path or a metrics subpath. Fix the Ingress shape,
+or disable the block only when public metrics exposure is intentional:
+
+```yaml
+serviceMonitor:
+  blockExternalIngress:
+    enabled: false
+```
+
+If the public route differs from the in-cluster scrape path, set
+`serviceMonitor.blockExternalIngress.path`:
+
+```yaml
+serviceMonitor:
+  path: /internal/metrics
+  blockExternalIngress:
+    path: /app/metrics
+```
+
+From this chart directory, verify the rendered blocking Ingress before rollout:
+
+```bash
+helm template my-release . \
+  --set image.repository=example.com/app \
+  --set image.tag=latest \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set ingress.hosts[0].host=app.example.com \
+  --set ingress.hosts[0].paths[0].path=/ \
+  --set ingress.hosts[0].paths[0].pathType=Prefix \
+  --set serviceMonitor.enabled=true \
+  --show-only templates/metrics-block-ingress.yaml
+```
+
 ## Requirements
 
 | Repository | Name | Version |
@@ -176,11 +236,16 @@ elsewhere (TODO: add link here)
 | serviceAccount.automount | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
-| serviceMonitor | object | `{"alternatePort":null,"enabled":false,"interval":null,"path":"/metrics"}` | Configure a ServiceMonitor for scraping metrics from the service. |
+| serviceMonitor | object | `{"alternatePort":null,"blockExternalIngress":{"denylistSourceRange":"0.0.0.0/0,::/0","enabled":true,"ingressClassNames":["","nginx"],"path":null},"enabled":false,"interval":null,"path":"/metrics"}` | Configure a ServiceMonitor for scraping metrics from the service. |
 | serviceMonitor.alternatePort | string | `nil` | Optional alternate port to scrape via a dedicated "<release>-metrics" Service. When null, the ServiceMonitor targets the main service as before. |
+| serviceMonitor.blockExternalIngress | object | `{"denylistSourceRange":"0.0.0.0/0,::/0","enabled":true,"ingressClassNames":["","nginx"],"path":null}` | Block public nginx ingress access to the metrics path while allowing Prometheus to continue scraping through the in-cluster ServiceMonitor. This is enabled by default because public metrics endpoints can expose sensitive service internals. Disable only when the metrics endpoint must be publicly reachable. |
+| serviceMonitor.blockExternalIngress.denylistSourceRange | string | `"0.0.0.0/0,::/0"` | Comma-separated CIDR source ranges denied by the generated metrics-blocking Ingress. |
+| serviceMonitor.blockExternalIngress.enabled | bool | `true` | Whether to create the additional nginx Ingress when ingress.enabled, serviceMonitor.enabled, an allowed ingress class, and a block path are all present. |
+| serviceMonitor.blockExternalIngress.ingressClassNames | list | `["","nginx"]` | Ingress class names known to be served by ingress-nginx. Include "" for classless Ingresses handled by a default ingress-nginx controller. |
+| serviceMonitor.blockExternalIngress.path | string | `nil` | Public ingress path to deny. When null, serviceMonitor.path is used. When both values are null, "/metrics" is used to match Prometheus' default scrape path. Set this when the public route differs from the in-cluster scrape path. |
 | serviceMonitor.enabled | bool | `false` | Whether to create a ServiceMonitor resource. |
 | serviceMonitor.interval | string | `nil` | Optional scrape interval (in seconds). When null, the operator default is used. |
-| serviceMonitor.path | string | `"/metrics"` | HTTP path to scrape for metrics. |
+| serviceMonitor.path | string | `"/metrics"` | HTTP path to scrape for metrics. Must start with "/". |
 | spread_azs | boolean | `false` | Add a topology spread rule across Karpenter availability zones. |
 | spread_spot | boolean | `false` | Add a topology spread rule across Karpenter capacity types (spot vs on-demand). |
 | startupProbe | string | `nil` | Configure a startup probe to check if the application has started successfully. The startup probe is used to give the application more time to start up before the liveness probe takes over. This is especially useful for applications that take a long time to initialize. Once the startup probe succeeds once, Kubernetes will stop using it and switch to the liveness probe for ongoing health checks. More information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ Example configuration:   startupProbe:     httpGet:       path: /diagnostics/health       port: http     periodSeconds: 5     failureThreshold: 60 |

--- a/charts/universal-chart/README.md.gotmpl
+++ b/charts/universal-chart/README.md.gotmpl
@@ -27,6 +27,66 @@ Of note: the ingress configuration always goes in the Argo Application, not in
 your values YAML. An explanation of how Argo Applications work is documented
 elsewhere (TODO: add link here)
 
+## Public Metrics Blocking
+
+When both `ingress.enabled` and `serviceMonitor.enabled` are true, this chart
+creates an additional ingress-nginx Ingress that denies public access to the
+metrics path. The default block path is `serviceMonitor.path`; if that value is
+null, the block path defaults to `/metrics` to match Prometheus' default scrape
+path.
+
+The blocking Ingress renders only for ingress classes listed in
+`serviceMonitor.blockExternalIngress.ingressClassNames`, which defaults to
+`["", "nginx"]`. Include `""` for classless Ingresses handled by a default
+ingress-nginx controller. If your ingress-nginx controller uses another class
+name, add it explicitly:
+
+```yaml
+serviceMonitor:
+  blockExternalIngress:
+    ingressClassNames:
+      - ""
+      - nginx
+      - nginx-internal
+```
+
+The chart fails to render instead of silently leaving metrics public when the
+configured Ingress class is not known to be ingress-nginx, when the primary
+Ingress uses nginx regex or rewrite annotations, or when the primary Ingress
+already declares the metrics path or a metrics subpath. Fix the Ingress shape,
+or disable the block only when public metrics exposure is intentional:
+
+```yaml
+serviceMonitor:
+  blockExternalIngress:
+    enabled: false
+```
+
+If the public route differs from the in-cluster scrape path, set
+`serviceMonitor.blockExternalIngress.path`:
+
+```yaml
+serviceMonitor:
+  path: /internal/metrics
+  blockExternalIngress:
+    path: /app/metrics
+```
+
+From this chart directory, verify the rendered blocking Ingress before rollout:
+
+```bash
+helm template my-release . \
+  --set image.repository=example.com/app \
+  --set image.tag=latest \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set ingress.hosts[0].host=app.example.com \
+  --set ingress.hosts[0].paths[0].path=/ \
+  --set ingress.hosts[0].paths[0].pathType=Prefix \
+  --set serviceMonitor.enabled=true \
+  --show-only templates/metrics-block-ingress.yaml
+```
+
 
 {{ template "chart.requirementsSection" . }}
 

--- a/charts/universal-chart/docs/index.md
+++ b/charts/universal-chart/docs/index.md
@@ -19,7 +19,8 @@ Kubernetes primitives plus a small number of opinionated platform integrations.
 - `extraEnvVars`, `extraEnvSecrets`, and `extraEnvConfigmaps`
 - `extraManifests` for app-adjacent resources such as `ExternalSecret`,
   `Database`, `DbUser`, or one-off Jobs
-- optional `ServiceMonitor`
+- optional `ServiceMonitor`, with public nginx ingress access to the metrics
+  path blocked by default
 - first-class HPA scaling from Prometheus-backed external metrics through
   `autoscaling.hpaScalingRules`
 - optional Redis support
@@ -27,6 +28,37 @@ Kubernetes primitives plus a small number of opinionated platform integrations.
 - extra volumes and mounts
 - spread helpers for AZ and spot-aware scheduling
 - `terminationGracePeriodSeconds` for workloads that need slower shutdown
+
+## Public Metrics Blocking
+
+When `serviceMonitor.enabled` and nginx ingress are both enabled, the chart
+renders a separate metrics-blocking Ingress by default. This also applies to
+classless Ingresses served by the default ingress-nginx controller. The block
+Ingress uses `nginx.ingress.kubernetes.io/denylist-source-range` for the
+ServiceMonitor path, so Prometheus can keep scraping through the in-cluster
+service while external requests to the public metrics route receive `403`.
+If an explicit non-`nginx` ingress class is set, the chart fails to render
+instead of silently leaving metrics public.
+If an ingress-nginx controller uses another class name, add that name to
+`serviceMonitor.blockExternalIngress.ingressClassNames`.
+
+The chart fails to render if the primary Ingress explicitly declares the
+metrics path or a metrics subpath while the block Ingress is active. Redirects
+to the metrics path can stay on other primary Ingress paths; the redirected
+metrics request is then handled by the block Ingress.
+
+The chart fails to render when metrics blocking is enabled and the primary
+Ingress uses nginx regex matching or `rewrite-target`. In that case,
+ingress-nginx path precedence can route around a separate block Ingress. Remove
+the regex/rewrite ingress annotations, or set
+`serviceMonitor.blockExternalIngress.enabled: false` only when public metrics
+are intentional.
+
+Set `serviceMonitor.blockExternalIngress.enabled: false` only for apps that
+intentionally expose metrics publicly. If the public route differs from the
+in-cluster scrape path, set `serviceMonitor.blockExternalIngress.path`. When
+both the block path and `serviceMonitor.path` are null, the block path defaults
+to `/metrics`, matching Prometheus' default scrape path.
 
 ## Recommended Ownership Split
 

--- a/charts/universal-chart/templates/metrics-block-ingress.yaml
+++ b/charts/universal-chart/templates/metrics-block-ingress.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.ingress.enabled -}}
+{{- $block := .Values.serviceMonitor.blockExternalIngress -}}
+{{- $annotations := .Values.ingress.annotations | default dict -}}
+{{- $blockPath := coalesce $block.path .Values.serviceMonitor.path "/metrics" -}}
+{{- $blockComparePath := trimSuffix "/" $blockPath -}}
+{{- if eq $blockComparePath "" -}}
+{{- $blockComparePath = "/" -}}
+{{- end -}}
+{{- $annotationIngressClass := index $annotations "kubernetes.io/ingress.class" | default "" -}}
+{{- $specIngressClass := .Values.ingress.className | default "" -}}
+{{- $ingressClass := coalesce $specIngressClass $annotationIngressClass | default "" -}}
+{{- $blockRequested := and .Values.serviceMonitor.enabled $block.enabled $blockPath -}}
+{{- $nginxIngressClasses := $block.ingressClassNames | default (list "" "nginx") -}}
+{{- $nginxClass := has $ingressClass $nginxIngressClasses -}}
+{{- if and $blockRequested (not $nginxClass) -}}
+{{- fail "serviceMonitor.blockExternalIngress is nginx-specific and cannot safely block metrics for this ingress class; disable serviceMonitor.blockExternalIngress only when public metrics are intentional" -}}
+{{- end -}}
+{{- $blockEnabled := and $blockRequested $nginxClass -}}
+{{- $useRegexValue := lower (toString (index $annotations "nginx.ingress.kubernetes.io/use-regex")) -}}
+{{- $usesRegexIngress := or (eq $useRegexValue "true") (eq $useRegexValue "1") (eq $useRegexValue "t") (hasKey $annotations "nginx.ingress.kubernetes.io/rewrite-target") -}}
+{{- if and $blockEnabled $usesRegexIngress -}}
+{{- fail "serviceMonitor.blockExternalIngress cannot safely block metrics when ingress annotations enable nginx regex matching or rewrite-target; disable serviceMonitor.blockExternalIngress only when public metrics are intentional, or remove the regex/rewrite ingress annotations" -}}
+{{- end -}}
+{{- range .Values.ingress.hosts -}}
+{{- range .paths -}}
+{{- $ingressComparePath := trimSuffix "/" .path -}}
+{{- if eq $ingressComparePath "" -}}
+{{- $ingressComparePath = "/" -}}
+{{- end -}}
+{{- $ingressBlockedPath := or (eq $ingressComparePath $blockComparePath) (and (ne $blockComparePath "/") (hasPrefix (printf "%s/" $blockComparePath) $ingressComparePath)) -}}
+{{- if and $blockEnabled $ingressBlockedPath -}}
+{{- fail "serviceMonitor.blockExternalIngress cannot safely block metrics when the primary ingress also declares the metrics path or a metrics subpath; remove that primary ingress path or disable serviceMonitor.blockExternalIngress only when public metrics are intentional" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $blockEnabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "universal-chart.fullname" . }}-metrics-block
+  labels:
+    {{- include "universal-chart.labels" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/denylist-source-range: {{ $block.denylistSourceRange | quote }}
+    {{- if and (not $specIngressClass) $annotationIngressClass }}
+    kubernetes.io/ingress.class: {{ $annotationIngressClass | quote }}
+    {{- end }}
+spec:
+  {{- with $specIngressClass }}
+  ingressClassName: {{ $specIngressClass }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName | default "tls" }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: {{ $blockComparePath }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "universal-chart.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/universal-chart/values.schema.json
+++ b/charts/universal-chart/values.schema.json
@@ -50,7 +50,8 @@
         "path": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "string",
+              "pattern": "^/.*"
             },
             {
               "type": "null"
@@ -79,6 +80,35 @@
               "type": "null"
             }
           ]
+        },
+        "blockExternalIngress": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "path": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^/.*"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "denylistSourceRange": {
+              "type": "string",
+              "pattern": "^\\s*([0-9A-Fa-f:.]+/[0-9]{1,3})(\\s*,\\s*[0-9A-Fa-f:.]+/[0-9]{1,3})*\\s*$"
+            },
+            "ingressClassNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },

--- a/charts/universal-chart/values.yaml
+++ b/charts/universal-chart/values.yaml
@@ -278,6 +278,7 @@ service:
 #   path:
 #     anyof:
 #       - type: string
+#         pattern: ^/.*
 #       - type: "null"
 #   interval:
 #     anyof:
@@ -290,18 +291,56 @@ service:
 #         minimum: 1
 #         maximum: 65535
 #       - type: "null"
+#   blockExternalIngress:
+#     type: object
+#     properties:
+#       enabled:
+#         type: boolean
+#       path:
+#         anyof:
+#           - type: string
+#             pattern: ^/.*
+#           - type: "null"
+#       denylistSourceRange:
+#         type: string
+#         pattern: '^\s*([0-9A-Fa-f:.]+/[0-9]{1,3})(\s*,\s*[0-9A-Fa-f:.]+/[0-9]{1,3})*\s*$'
+#       ingressClassNames:
+#         type: array
+#         items:
+#           type: string
 # @schema
 # -- Configure a ServiceMonitor for scraping metrics from the service.
 serviceMonitor:
   # -- Whether to create a ServiceMonitor resource.
   enabled: false
-  # -- HTTP path to scrape for metrics.
+  # -- HTTP path to scrape for metrics. Must start with "/".
   path: /metrics
   # -- Optional scrape interval (in seconds). When null, the operator default is used.
   interval: null
   # -- Optional alternate port to scrape via a dedicated "<release>-metrics" Service.
   # When null, the ServiceMonitor targets the main service as before.
   alternatePort: null
+  # -- Block public nginx ingress access to the metrics path while allowing
+  # Prometheus to continue scraping through the in-cluster ServiceMonitor.
+  # This is enabled by default because public metrics endpoints can expose
+  # sensitive service internals. Disable only when the metrics endpoint must be
+  # publicly reachable.
+  blockExternalIngress:
+    # -- Whether to create the additional nginx Ingress when ingress.enabled,
+    # serviceMonitor.enabled, an allowed ingress class, and a block path are all present.
+    enabled: true
+    # -- Public ingress path to deny. When null, serviceMonitor.path is used.
+    # When both values are null, "/metrics" is used to match Prometheus'
+    # default scrape path. Set this when the public route differs from the
+    # in-cluster scrape path.
+    path: null
+    # -- Comma-separated CIDR source ranges denied by the generated metrics-blocking Ingress.
+    denylistSourceRange: "0.0.0.0/0,::/0"
+    # -- Ingress class names known to be served by ingress-nginx. Include ""
+    # for classless Ingresses handled by a default ingress-nginx controller.
+    ingressClassNames:
+      - ""
+      - nginx
 
 # @schema
 # properties:

--- a/tests/fixtures/universal-chart/metrics-block-disabled-values.golden.yaml
+++ b/tests/fixtures/universal-chart/metrics-block-disabled-values.golden.yaml
@@ -1,0 +1,130 @@
+---
+# Source: universal-chart/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: universal-chart
+  labels:
+    helm.sh/chart: universal-chart-0.0.0-a.placeholder
+    app.kubernetes.io/name: universal-chart
+    app.kubernetes.io/instance: universal-chart
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: universal-chart/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: universal-chart
+  labels:
+    helm.sh/chart: universal-chart-0.0.0-a.placeholder
+    app.kubernetes.io/name: universal-chart
+    app.kubernetes.io/instance: universal-chart
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: universal-chart
+    app.kubernetes.io/instance: universal-chart
+---
+# Source: universal-chart/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: universal-chart
+  labels:
+    helm.sh/chart: universal-chart-0.0.0-a.placeholder
+    app.kubernetes.io/name: universal-chart
+    app.kubernetes.io/instance: universal-chart
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: universal-chart
+      app.kubernetes.io/instance: universal-chart
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: universal-chart-0.0.0-a.placeholder
+        app.kubernetes.io/name: universal-chart
+        app.kubernetes.io/instance: universal-chart
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: universal-chart
+      containers:
+        - name: universal-chart
+          env: &containerenv
+            # placeholder var so we can always make an env list
+            - name: REDIS_ENABLED
+              value: "false"
+          image: "ghcr.io/example/app:1.2.3"
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: universal-chart
+              app.kubernetes.io/name: universal-chart
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+---
+# Source: universal-chart/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: universal-chart
+  labels:
+    helm.sh/chart: universal-chart-0.0.0-a.placeholder
+    app.kubernetes.io/name: universal-chart
+    app.kubernetes.io/instance: universal-chart
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - "app.example.com"
+      secretName: app-example-com
+  rules:
+    - host: "app.example.com"
+      http:
+        paths:
+          - path: /(app)(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: universal-chart
+                port:
+                  number: 3000
+---
+# Source: universal-chart/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: universal-chart
+  labels:
+    helm.sh/chart: universal-chart-0.0.0-a.placeholder
+    app.kubernetes.io/name: universal-chart
+    app.kubernetes.io/instance: universal-chart
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: universal-chart
+      app.kubernetes.io/instance: universal-chart
+  endpoints:
+    - port: http
+      path: /app/metrics

--- a/tests/fixtures/universal-chart/metrics-block-disabled-values.yaml
+++ b/tests/fixtures/universal-chart/metrics-block-disabled-values.yaml
@@ -1,0 +1,23 @@
+image:
+  repository: ghcr.io/example/app
+  tag: "1.2.3"
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: "/$1"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+  hosts:
+    - host: app.example.com
+      paths:
+        - path: /(app)(/|$)(.*)
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: app-example-com
+      hosts:
+        - app.example.com
+serviceMonitor:
+  enabled: true
+  path: /app/metrics
+  blockExternalIngress:
+    enabled: false

--- a/tests/test_universal_chart.py
+++ b/tests/test_universal_chart.py
@@ -690,6 +690,17 @@ def test_service_monitor_rejects_invalid_enabled_value(helm_runner) -> None:
         )
 
 
+def test_service_monitor_rejects_invalid_path_value(helm_runner) -> None:
+    """Reject scrape paths that cannot also be used as ingress paths."""
+
+    with pytest.raises(HelmTemplateError):
+        render_chart(
+            helm_runner,
+            CHART,
+            values={"serviceMonitor": {"enabled": True, "path": "metrics"}},
+        )
+
+
 def test_service_monitor_interval_rejects_negative_values(helm_runner) -> None:
     """Ensure the schema rejects negative interval values."""
 

--- a/tests/test_universal_chart_metrics_block.py
+++ b/tests/test_universal_chart_metrics_block.py
@@ -1,0 +1,483 @@
+"""Tests for universal-chart public metrics blocking."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from .chart_test_utils import (
+    ChartContext,
+    get_manifest,
+    load_manifests,
+    render_chart,
+)
+from .conftest import HelmTemplateError
+
+CHART = ChartContext("universal-chart")
+
+
+def _ingresses_by_name(
+    manifests: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Return ingress manifests keyed by name."""
+
+    return {
+        manifest["metadata"]["name"]: manifest
+        for manifest in manifests
+        if manifest.get("kind") == "Ingress"
+    }
+
+
+def _nginx_ingress_values(
+    *,
+    paths: list[dict[str, str]] | None = None,
+    annotations: dict[str, str] | None = None,
+    class_name: str | None = "nginx",
+) -> dict[str, Any]:
+    """Return values for an nginx ingress with metrics scraping enabled."""
+
+    ingress: dict[str, Any] = {
+        "enabled": True,
+        "hosts": [
+            {
+                "host": "app.example.com",
+                "paths": paths or [{"path": "/", "pathType": "Prefix"}],
+            }
+        ],
+    }
+    if class_name is not None:
+        ingress["className"] = class_name
+    if annotations is not None:
+        ingress["annotations"] = annotations
+
+    return {
+        "ingress": ingress,
+        "serviceMonitor": {"enabled": True, "path": "/metrics"},
+    }
+
+
+def test_metrics_block_ingress_renders_for_nginx_ingress(
+    helm_runner,
+) -> None:
+    """Ensure nginx ingress blocks public access to ServiceMonitor metrics."""
+
+    rendered = render_chart(
+        helm_runner,
+        CHART,
+        values={
+            "ingress": {
+                "enabled": True,
+                "className": "nginx",
+                "annotations": {
+                    "nginx.ingress.kubernetes.io/permanent-redirect": (
+                        "https://example.com"
+                    ),
+                },
+                "hosts": [
+                    {
+                        "host": "app.example.com",
+                        "paths": [{"path": "/", "pathType": "Prefix"}],
+                    },
+                    {
+                        "host": "alt.example.com",
+                        "paths": [{"path": "/", "pathType": "Prefix"}],
+                    },
+                ],
+                "tls": [
+                    {
+                        "secretName": "app-example-com",
+                        "hosts": ["app.example.com", "alt.example.com"],
+                    }
+                ],
+            },
+            "serviceMonitor": {"enabled": True, "path": "/metrics"},
+        },
+    )
+    manifests = load_manifests(rendered)
+    ingresses = _ingresses_by_name(manifests)
+    main = ingresses[CHART.release]
+    block = ingresses[f"{CHART.release}-metrics-block"]
+
+    assert set(ingresses) == {CHART.release, f"{CHART.release}-metrics-block"}
+    assert main["spec"]["rules"][0]["http"]["paths"][0]["path"] == "/"
+    assert block["metadata"]["annotations"] == {
+        "nginx.ingress.kubernetes.io/denylist-source-range": "0.0.0.0/0,::/0"
+    }
+    assert block["spec"]["ingressClassName"] == "nginx"
+    assert block["spec"]["tls"][0]["secretName"] == "app-example-com"
+
+    rules = block["spec"]["rules"]
+    assert [rule["host"] for rule in rules] == [
+        "app.example.com",
+        "alt.example.com",
+    ]
+    assert all(rule["http"]["paths"][0]["path"] == "/metrics" for rule in rules)
+    assert all(
+        rule["http"]["paths"][0]["pathType"] == "Prefix" for rule in rules
+    )
+
+
+@pytest.mark.parametrize("path", ["/metrics/", "/metrics/debug"])
+def test_metrics_block_ingress_rejects_duplicate_primary_path(
+    helm_runner,
+    path: str,
+) -> None:
+    """Reject primary paths that would compete with the block Ingress."""
+
+    with pytest.raises(HelmTemplateError):
+        render_chart(
+            helm_runner,
+            CHART,
+            values=_nginx_ingress_values(
+                paths=[
+                    {"path": "/", "pathType": "Prefix"},
+                    {"path": path, "pathType": "Prefix"},
+                ]
+            ),
+        )
+
+
+def test_metrics_block_ingress_uses_prometheus_default_path_when_null(
+    helm_runner,
+) -> None:
+    """Block /metrics when ServiceMonitor omits path."""
+
+    rendered = render_chart(
+        helm_runner,
+        CHART,
+        values={
+            "ingress": {
+                "enabled": True,
+                "className": "nginx",
+                "hosts": [
+                    {
+                        "host": "app.example.com",
+                        "paths": [{"path": "/", "pathType": "Prefix"}],
+                    }
+                ],
+            },
+            "serviceMonitor": {"enabled": True, "path": None},
+        },
+    )
+    manifests = load_manifests(rendered)
+    ingresses = _ingresses_by_name(manifests)
+    endpoint = get_manifest(manifests, "ServiceMonitor")["spec"]["endpoints"][0]
+    block_path = ingresses[f"{CHART.release}-metrics-block"]["spec"]["rules"][
+        0
+    ]["http"]["paths"][0]
+
+    assert "path" not in endpoint
+    assert block_path["path"] == "/metrics"
+
+
+def test_metrics_block_ingress_renders_for_classless_ingress(
+    helm_runner,
+) -> None:
+    """Mirror classless ingresses for default ingress-nginx controllers."""
+
+    rendered = render_chart(
+        helm_runner,
+        CHART,
+        values={
+            "ingress": {
+                "enabled": True,
+                "hosts": [
+                    {
+                        "host": "app.example.com",
+                        "paths": [{"path": "/", "pathType": "Prefix"}],
+                    }
+                ],
+            },
+            "serviceMonitor": {"enabled": True},
+        },
+    )
+    manifests = load_manifests(rendered)
+    ingresses = _ingresses_by_name(manifests)
+    block = ingresses[f"{CHART.release}-metrics-block"]
+
+    assert "ingressClassName" not in block["spec"]
+
+
+def test_metrics_block_ingress_handles_null_annotations(
+    helm_runner,
+) -> None:
+    """Avoid failing when callers explicitly set ingress.annotations to null."""
+
+    rendered = render_chart(
+        helm_runner,
+        CHART,
+        values={
+            "ingress": {
+                "enabled": True,
+                "className": "nginx",
+                "annotations": None,
+                "hosts": [
+                    {
+                        "host": "app.example.com",
+                        "paths": [{"path": "/", "pathType": "Prefix"}],
+                    }
+                ],
+            },
+            "serviceMonitor": {"enabled": True},
+        },
+    )
+    manifests = load_manifests(rendered)
+    ingresses = _ingresses_by_name(manifests)
+
+    assert f"{CHART.release}-metrics-block" in ingresses
+
+
+def test_metrics_block_ingress_uses_public_path_override(
+    helm_runner,
+) -> None:
+    """Allow apps to block a public path that differs from the scrape path."""
+
+    rendered = render_chart(
+        helm_runner,
+        CHART,
+        values={
+            "ingress": {
+                "enabled": True,
+                "annotations": {"kubernetes.io/ingress.class": "nginx"},
+                "hosts": [
+                    {
+                        "host": "app.example.com",
+                        "paths": [{"path": "/", "pathType": "Prefix"}],
+                    }
+                ],
+            },
+            "serviceMonitor": {
+                "enabled": True,
+                "path": "/internal/metrics",
+                "blockExternalIngress": {"path": "/app/metrics"},
+            },
+        },
+    )
+    manifests = load_manifests(rendered)
+    ingresses = _ingresses_by_name(manifests)
+    block = ingresses[f"{CHART.release}-metrics-block"]
+    block_path = ingresses[f"{CHART.release}-metrics-block"]["spec"]["rules"][
+        0
+    ]["http"]["paths"][0]
+
+    assert block["metadata"]["annotations"] == {
+        "kubernetes.io/ingress.class": "nginx",
+        "nginx.ingress.kubernetes.io/denylist-source-range": "0.0.0.0/0,::/0",
+    }
+    assert "ingressClassName" not in block["spec"]
+    assert block_path["path"] == "/app/metrics"
+    assert block_path["pathType"] == "Prefix"
+
+
+def test_metrics_block_ingress_rejects_rewrite_ingress(
+    helm_runner,
+) -> None:
+    """Reject ingress rules where nginx path precedence cannot be guaranteed."""
+
+    with pytest.raises(HelmTemplateError):
+        render_chart(
+            helm_runner,
+            CHART,
+            values={
+                "ingress": {
+                    "enabled": True,
+                    "className": "nginx",
+                    "annotations": {
+                        "nginx.ingress.kubernetes.io/rewrite-target": "/$3",
+                    },
+                    "hosts": [
+                        {
+                            "host": "app.example.com",
+                            "paths": [
+                                {
+                                    "path": "/(app)(/|$)(.*)",
+                                    "pathType": "ImplementationSpecific",
+                                }
+                            ],
+                        }
+                    ],
+                },
+                "serviceMonitor": {
+                    "enabled": True,
+                    "path": "/metrics",
+                    "blockExternalIngress": {"path": "/app/metrics"},
+                },
+            },
+        )
+
+
+def test_metrics_block_ingress_rejects_case_variant_regex_ingress(
+    helm_runner,
+) -> None:
+    """Reject nginx truthy use-regex values beyond lowercase true."""
+
+    with pytest.raises(HelmTemplateError):
+        render_chart(
+            helm_runner,
+            CHART,
+            values={
+                "ingress": {
+                    "enabled": True,
+                    "className": "nginx",
+                    "annotations": {
+                        "nginx.ingress.kubernetes.io/use-regex": "True",
+                    },
+                    "hosts": [
+                        {
+                            "host": "app.example.com",
+                            "paths": [
+                                {
+                                    "path": "/(app)(/|$)(.*)",
+                                    "pathType": "ImplementationSpecific",
+                                }
+                            ],
+                        }
+                    ],
+                },
+                "serviceMonitor": {"enabled": True},
+            },
+        )
+
+
+def test_metrics_block_ingress_rejects_unsupported_ingress_class(
+    helm_runner,
+) -> None:
+    """Reject classes where the nginx deny rule cannot be safely enforced."""
+
+    with pytest.raises(HelmTemplateError):
+        render_chart(
+            helm_runner,
+            CHART,
+            values={
+                "ingress": {
+                    "enabled": True,
+                    "className": "alb",
+                    "hosts": [
+                        {
+                            "host": "app.example.com",
+                            "paths": [{"path": "/", "pathType": "Prefix"}],
+                        }
+                    ],
+                },
+                "serviceMonitor": {"enabled": True},
+            },
+        )
+
+
+def test_metrics_block_ingress_allows_configured_nginx_class(
+    helm_runner,
+) -> None:
+    """Allow alternate class names when they are known to use ingress-nginx."""
+
+    rendered = render_chart(
+        helm_runner,
+        CHART,
+        values={
+            "ingress": {
+                "enabled": True,
+                "className": "nginx-internal",
+                "hosts": [
+                    {
+                        "host": "app.example.com",
+                        "paths": [{"path": "/", "pathType": "Prefix"}],
+                    }
+                ],
+            },
+            "serviceMonitor": {
+                "enabled": True,
+                "blockExternalIngress": {
+                    "ingressClassNames": ["", "nginx", "nginx-internal"],
+                },
+            },
+        },
+    )
+    manifests = load_manifests(rendered)
+    ingresses = _ingresses_by_name(manifests)
+    block = ingresses[f"{CHART.release}-metrics-block"]
+
+    assert block["spec"]["ingressClassName"] == "nginx-internal"
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"serviceMonitor": {"enabled": True}},
+        {
+            "ingress": {
+                "enabled": True,
+                "className": "nginx",
+                "hosts": [
+                    {
+                        "host": "app.example.com",
+                        "paths": [{"path": "/", "pathType": "Prefix"}],
+                    }
+                ],
+            },
+            "serviceMonitor": {"enabled": False},
+        },
+        {
+            "ingress": {
+                "enabled": True,
+                "className": "nginx",
+                "hosts": [
+                    {
+                        "host": "app.example.com",
+                        "paths": [{"path": "/", "pathType": "Prefix"}],
+                    }
+                ],
+            },
+            "serviceMonitor": {
+                "enabled": True,
+                "blockExternalIngress": {"enabled": False},
+            },
+        },
+    ],
+)
+def test_metrics_block_ingress_is_conditional(
+    helm_runner,
+    values: dict[str, Any],
+) -> None:
+    """Ensure the public metrics block only renders when it can be enforced."""
+
+    rendered = render_chart(helm_runner, CHART, values=values)
+    manifests = load_manifests(rendered)
+    ingresses = _ingresses_by_name(manifests)
+
+    assert f"{CHART.release}-metrics-block" not in ingresses
+
+
+def test_metrics_block_rejects_invalid_enabled_value(helm_runner) -> None:
+    """Reject non-boolean values for the public metrics block toggle."""
+
+    with pytest.raises(HelmTemplateError):
+        render_chart(
+            helm_runner,
+            CHART,
+            values={
+                "serviceMonitor": {
+                    "enabled": True,
+                    "blockExternalIngress": {"enabled": "hero"},
+                }
+            },
+        )
+
+
+def test_metrics_block_rejects_invalid_denylist_source_range(
+    helm_runner,
+) -> None:
+    """Reject denylist values that are not CIDR-shaped."""
+
+    with pytest.raises(HelmTemplateError):
+        render_chart(
+            helm_runner,
+            CHART,
+            values={
+                "serviceMonitor": {
+                    "enabled": True,
+                    "blockExternalIngress": {
+                        "denylistSourceRange": "not-a-cidr",
+                    },
+                }
+            },
+        )


### PR DESCRIPTION
## Summary
- Add `serviceMonitor.blockExternalIngress` and enable it by default.
- Render a separate nginx metrics-blocking Ingress when ingress and metrics are both enabled.
- Reuse the main ingress hosts/TLS/service backend, but intentionally do not copy main ingress annotations so redirect/rewrite/auth annotations do not affect the block rule.
- Remove exact metrics paths and metrics subpaths from the primary Ingress while the block Ingress is active so ingress-nginx cannot route duplicate paths to the older primary rule.
- Fail closed when blocking is requested for explicit non-nginx ingress classes or nginx regex/rewrite annotations, where the chart cannot safely guarantee the deny rule wins.
- Document the behavior, default path detection, opt-out, and failure cases.

## Breaking change
This blocks a path that was previously public for universal-chart apps with nginx ingress and `serviceMonitor.enabled: true`. It can also fail rendering for apps that combine metrics blocking with explicit non-nginx ingress classes or nginx regex/rewrite annotations. This should be released as a major version change; the commit and PR title include `#major` for release automation.

## Reviews
- Security review: xhigh subagent review completed. Findings were addressed by removing duplicate/subpath primary routes, normalizing metrics paths, failing closed for regex/rewrite and unsupported classes, handling null annotations, defaulting null ServiceMonitor paths to `/metrics`, and tightening schema validation.
- Code quality / accuracy review: xhigh subagent review completed. Findings were addressed with additional unit coverage and docs/schema updates.

## Tests
- `/home/sauer/dev/herodevs/helm-charts/.venv/bin/python -m pytest --skip-helm-network` (`119 passed`)
- `/home/sauer/dev/herodevs/helm-charts/.venv/bin/python -m pytest tests/test_universal_chart.py tests/test_universal_chart_golden.py --skip-helm-network` (`85 passed`)
- `pre-commit run --all-files`

Closes #133
