### PR TITLE
feat: support regex for metrics blocking ingress

### DIFF
--- a/charts/universal-chart/README.md
+++ b/charts/universal-chart/README.md
@@ -107,15 +107,28 @@ serviceMonitor:
 ```
 
 The chart fails to render instead of silently leaving metrics public when the
-configured Ingress class is not known to be ingress-nginx, when the primary
-Ingress uses nginx regex or rewrite annotations, or when the primary Ingress
-already declares the metrics path or a metrics subpath. Fix the Ingress shape,
-or disable the block only when public metrics exposure is intentional:
+configured Ingress class is not known to be ingress-nginx or when the primary
+Ingress already declares the metrics path or a metrics subpath. Fix the Ingress
+shape, or disable the block only when public metrics exposure is intentional:
 
 ```yaml
 serviceMonitor:
   blockExternalIngress:
     enabled: false
+```
+
+By default, the chart also fails when the primary Ingress uses nginx regex or
+rewrite annotations because ingress-nginx path ordering can route around a
+separate blocking Ingress. If the app needs regex/rewrite ingress, opt in with a
+more-specific public metrics regex and `ImplementationSpecific` path type:
+
+```yaml
+serviceMonitor:
+  path: /eol/api/metrics
+  blockExternalIngress:
+    allowRegexIngress: true
+    path: /eol/api/metrics(/|$)(.*)
+    pathType: ImplementationSpecific
 ```
 
 If the public route differs from the in-cluster scrape path, set
@@ -236,13 +249,15 @@ helm template my-release . \
 | serviceAccount.automount | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
-| serviceMonitor | object | `{"alternatePort":null,"blockExternalIngress":{"denylistSourceRange":"0.0.0.0/0,::/0","enabled":true,"ingressClassNames":["","nginx"],"path":null},"enabled":false,"interval":null,"path":"/metrics"}` | Configure a ServiceMonitor for scraping metrics from the service. |
+| serviceMonitor | object | `{"alternatePort":null,"blockExternalIngress":{"allowRegexIngress":false,"denylistSourceRange":"0.0.0.0/0,::/0","enabled":true,"ingressClassNames":["","nginx"],"path":null,"pathType":"Prefix"},"enabled":false,"interval":null,"path":"/metrics"}` | Configure a ServiceMonitor for scraping metrics from the service. |
 | serviceMonitor.alternatePort | string | `nil` | Optional alternate port to scrape via a dedicated "<release>-metrics" Service. When null, the ServiceMonitor targets the main service as before. |
-| serviceMonitor.blockExternalIngress | object | `{"denylistSourceRange":"0.0.0.0/0,::/0","enabled":true,"ingressClassNames":["","nginx"],"path":null}` | Block public nginx ingress access to the metrics path while allowing Prometheus to continue scraping through the in-cluster ServiceMonitor. This is enabled by default because public metrics endpoints can expose sensitive service internals. Disable only when the metrics endpoint must be publicly reachable. |
+| serviceMonitor.blockExternalIngress | object | `{"allowRegexIngress":false,"denylistSourceRange":"0.0.0.0/0,::/0","enabled":true,"ingressClassNames":["","nginx"],"path":null,"pathType":"Prefix"}` | Block public nginx ingress access to the metrics path while allowing Prometheus to continue scraping through the in-cluster ServiceMonitor. This is enabled by default because public metrics endpoints can expose sensitive service internals. Disable only when the metrics endpoint must be publicly reachable. |
+| serviceMonitor.blockExternalIngress.allowRegexIngress | bool | `false` | Allow metrics blocking when the primary Ingress uses nginx regex or rewrite annotations. Requires blockExternalIngress.path to be set to a more-specific public metrics regex that wins ingress-nginx path ordering. |
 | serviceMonitor.blockExternalIngress.denylistSourceRange | string | `"0.0.0.0/0,::/0"` | Comma-separated CIDR source ranges denied by the generated metrics-blocking Ingress. |
 | serviceMonitor.blockExternalIngress.enabled | bool | `true` | Whether to create the additional nginx Ingress when ingress.enabled, serviceMonitor.enabled, an allowed ingress class, and a block path are all present. |
 | serviceMonitor.blockExternalIngress.ingressClassNames | list | `["","nginx"]` | Ingress class names known to be served by ingress-nginx. Include "" for classless Ingresses handled by a default ingress-nginx controller. |
 | serviceMonitor.blockExternalIngress.path | string | `nil` | Public ingress path to deny. When null, serviceMonitor.path is used. When both values are null, "/metrics" is used to match Prometheus' default scrape path. Set this when the public route differs from the in-cluster scrape path. |
+| serviceMonitor.blockExternalIngress.pathType | string | `"Prefix"` | Path type for the generated metrics-blocking Ingress. |
 | serviceMonitor.enabled | bool | `false` | Whether to create a ServiceMonitor resource. |
 | serviceMonitor.interval | string | `nil` | Optional scrape interval (in seconds). When null, the operator default is used. |
 | serviceMonitor.path | string | `"/metrics"` | HTTP path to scrape for metrics. Must start with "/". |

--- a/charts/universal-chart/README.md.gotmpl
+++ b/charts/universal-chart/README.md.gotmpl
@@ -51,15 +51,28 @@ serviceMonitor:
 ```
 
 The chart fails to render instead of silently leaving metrics public when the
-configured Ingress class is not known to be ingress-nginx, when the primary
-Ingress uses nginx regex or rewrite annotations, or when the primary Ingress
-already declares the metrics path or a metrics subpath. Fix the Ingress shape,
-or disable the block only when public metrics exposure is intentional:
+configured Ingress class is not known to be ingress-nginx or when the primary
+Ingress already declares the metrics path or a metrics subpath. Fix the Ingress
+shape, or disable the block only when public metrics exposure is intentional:
 
 ```yaml
 serviceMonitor:
   blockExternalIngress:
     enabled: false
+```
+
+By default, the chart also fails when the primary Ingress uses nginx regex or
+rewrite annotations because ingress-nginx path ordering can route around a
+separate blocking Ingress. If the app needs regex/rewrite ingress, opt in with a
+more-specific public metrics regex and `ImplementationSpecific` path type:
+
+```yaml
+serviceMonitor:
+  path: /eol/api/metrics
+  blockExternalIngress:
+    allowRegexIngress: true
+    path: /eol/api/metrics(/|$)(.*)
+    pathType: ImplementationSpecific
 ```
 
 If the public route differs from the in-cluster scrape path, set

--- a/charts/universal-chart/docs/index.md
+++ b/charts/universal-chart/docs/index.md
@@ -47,12 +47,14 @@ metrics path or a metrics subpath while the block Ingress is active. Redirects
 to the metrics path can stay on other primary Ingress paths; the redirected
 metrics request is then handled by the block Ingress.
 
-The chart fails to render when metrics blocking is enabled and the primary
+The chart fails by default when metrics blocking is enabled and the primary
 Ingress uses nginx regex matching or `rewrite-target`. In that case,
-ingress-nginx path precedence can route around a separate block Ingress. Remove
-the regex/rewrite ingress annotations, or set
-`serviceMonitor.blockExternalIngress.enabled: false` only when public metrics
-are intentional.
+ingress-nginx path precedence can route around a separate block Ingress. If the
+app needs regex/rewrite ingress, set
+`serviceMonitor.blockExternalIngress.allowRegexIngress: true`, set
+`serviceMonitor.blockExternalIngress.path` to a more-specific public metrics
+regex, and set `serviceMonitor.blockExternalIngress.pathType` to
+`ImplementationSpecific`.
 
 Set `serviceMonitor.blockExternalIngress.enabled: false` only for apps that
 intentionally expose metrics publicly. If the public route differs from the

--- a/charts/universal-chart/templates/metrics-block-ingress.yaml
+++ b/charts/universal-chart/templates/metrics-block-ingress.yaml
@@ -18,8 +18,16 @@
 {{- $blockEnabled := and $blockRequested $nginxClass -}}
 {{- $useRegexValue := lower (toString (index $annotations "nginx.ingress.kubernetes.io/use-regex")) -}}
 {{- $usesRegexIngress := or (eq $useRegexValue "true") (eq $useRegexValue "1") (eq $useRegexValue "t") (hasKey $annotations "nginx.ingress.kubernetes.io/rewrite-target") -}}
-{{- if and $blockEnabled $usesRegexIngress -}}
-{{- fail "serviceMonitor.blockExternalIngress cannot safely block metrics when ingress annotations enable nginx regex matching or rewrite-target; disable serviceMonitor.blockExternalIngress only when public metrics are intentional, or remove the regex/rewrite ingress annotations" -}}
+{{- $allowRegexIngress := $block.allowRegexIngress | default false -}}
+{{- if and $blockEnabled $usesRegexIngress (not $allowRegexIngress) -}}
+{{- fail "serviceMonitor.blockExternalIngress cannot safely block metrics when ingress annotations enable nginx regex matching or rewrite-target unless serviceMonitor.blockExternalIngress.allowRegexIngress is true and serviceMonitor.blockExternalIngress.path is set to a more-specific public metrics regex; disable serviceMonitor.blockExternalIngress only when public metrics are intentional, or remove the regex/rewrite ingress annotations" -}}
+{{- end -}}
+{{- if and $blockEnabled $usesRegexIngress $allowRegexIngress (not $block.path) -}}
+{{- fail "serviceMonitor.blockExternalIngress.allowRegexIngress requires serviceMonitor.blockExternalIngress.path to be set to the public metrics path regex" -}}
+{{- end -}}
+{{- $blockPathType := coalesce $block.pathType "Prefix" -}}
+{{- if and $blockEnabled $usesRegexIngress $allowRegexIngress (ne $blockPathType "ImplementationSpecific") -}}
+{{- fail "serviceMonitor.blockExternalIngress.allowRegexIngress requires serviceMonitor.blockExternalIngress.pathType to be ImplementationSpecific" -}}
 {{- end -}}
 {{- range .Values.ingress.hosts -}}
 {{- range .paths -}}
@@ -65,7 +73,7 @@ spec:
       http:
         paths:
           - path: {{ $blockComparePath }}
-            pathType: Prefix
+            pathType: {{ $blockPathType }}
             backend:
               service:
                 name: {{ include "universal-chart.fullname" $ }}

--- a/charts/universal-chart/values.schema.json
+++ b/charts/universal-chart/values.schema.json
@@ -98,6 +98,17 @@
                 }
               ]
             },
+            "pathType": {
+              "type": "string",
+              "enum": [
+                "ImplementationSpecific",
+                "Exact",
+                "Prefix"
+              ]
+            },
+            "allowRegexIngress": {
+              "type": "boolean"
+            },
             "denylistSourceRange": {
               "type": "string",
               "pattern": "^\\s*([0-9A-Fa-f:.]+/[0-9]{1,3})(\\s*,\\s*[0-9A-Fa-f:.]+/[0-9]{1,3})*\\s*$"

--- a/charts/universal-chart/values.yaml
+++ b/charts/universal-chart/values.yaml
@@ -334,6 +334,12 @@ serviceMonitor:
     # default scrape path. Set this when the public route differs from the
     # in-cluster scrape path.
     path: null
+    # -- Path type for the generated metrics-blocking Ingress.
+    pathType: Prefix
+    # -- Allow metrics blocking when the primary Ingress uses nginx regex or
+    # rewrite annotations. Requires blockExternalIngress.path to be set to a
+    # more-specific public metrics regex that wins ingress-nginx path ordering.
+    allowRegexIngress: false
     # -- Comma-separated CIDR source ranges denied by the generated metrics-blocking Ingress.
     denylistSourceRange: "0.0.0.0/0,::/0"
     # -- Ingress class names known to be served by ingress-nginx. Include ""

--- a/tests/test_universal_chart_metrics_block.py
+++ b/tests/test_universal_chart_metrics_block.py
@@ -57,6 +57,33 @@ def _nginx_ingress_values(
     }
 
 
+def _regex_ingress_values(
+    *,
+    block_external_ingress: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return values for an nginx regex/rewrite ingress with metrics enabled."""
+
+    values = _nginx_ingress_values(
+        paths=[
+            {
+                "path": "/(eol)(/|$)(.*)",
+                "pathType": "ImplementationSpecific",
+            }
+        ],
+        annotations={
+            "nginx.ingress.kubernetes.io/rewrite-target": "/$1/$3",
+            "nginx.ingress.kubernetes.io/use-regex": "true",
+        },
+    )
+    values["serviceMonitor"]["path"] = "/eol/api/metrics"
+    if block_external_ingress is not None:
+        values["serviceMonitor"][
+            "blockExternalIngress"
+        ] = block_external_ingress
+
+    return values
+
+
 def test_metrics_block_ingress_renders_for_nginx_ingress(
     helm_runner,
 ) -> None:
@@ -304,6 +331,65 @@ def test_metrics_block_ingress_rejects_rewrite_ingress(
                     "blockExternalIngress": {"path": "/app/metrics"},
                 },
             },
+        )
+
+
+def test_metrics_block_ingress_renders_for_explicit_regex_ingress(
+    helm_runner,
+) -> None:
+    """Allow regex/rewrite ingress when given a specific block regex."""
+
+    rendered = render_chart(
+        helm_runner,
+        CHART,
+        values=_regex_ingress_values(
+            block_external_ingress={
+                "allowRegexIngress": True,
+                "path": "/eol/api/metrics(/|$)(.*)",
+                "pathType": "ImplementationSpecific",
+            }
+        ),
+    )
+    manifests = load_manifests(rendered)
+    ingresses = _ingresses_by_name(manifests)
+    block_path = ingresses[f"{CHART.release}-metrics-block"]["spec"]["rules"][
+        0
+    ]["http"]["paths"][0]
+
+    assert block_path["path"] == "/eol/api/metrics(/|$)(.*)"
+    assert block_path["pathType"] == "ImplementationSpecific"
+
+
+def test_metrics_block_ingress_regex_mode_requires_explicit_block_path(
+    helm_runner,
+) -> None:
+    """Require callers to specify the public metrics regex in regex mode."""
+
+    with pytest.raises(HelmTemplateError):
+        render_chart(
+            helm_runner,
+            CHART,
+            values=_regex_ingress_values(
+                block_external_ingress={"allowRegexIngress": True},
+            ),
+        )
+
+
+def test_metrics_block_ingress_regex_mode_requires_implementation_specific_path(
+    helm_runner,
+) -> None:
+    """Require ImplementationSpecific for regex metrics-block paths."""
+
+    with pytest.raises(HelmTemplateError):
+        render_chart(
+            helm_runner,
+            CHART,
+            values=_regex_ingress_values(
+                block_external_ingress={
+                    "allowRegexIngress": True,
+                    "path": "/eol/api/metrics(/|$)(.*)",
+                },
+            ),
         )
 
 


### PR DESCRIPTION
* adds support for a regex metrics blocking path to mitigate an issue where ingress nginx evaluates something like `/(path)(/|$)(.*)` before `/path/to/metrics` resulting in the metrics still being exposed on the primary ingress