### PR TITLE
fix: ingress-nginx versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,8 +109,11 @@ jobs:
           previous_tag=$(git tag -l "${tag_prefix}*" --sort=-version:refname | head -n1)
           echo "tag=$previous_tag" >> "$GITHUB_OUTPUT"
 
+      # ingress-nginx carries its authoritative release version in Chart.yaml.
+      # Other charts retain the existing tag-action versioning behavior.
       - name: Determine next tag
         id: next-tag
+        if: matrix.chart != 'ingress-nginx'
         uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -119,30 +122,37 @@ jobs:
           DEFAULT_BUMP: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.bump || 'patch' }}
           FORCE_WITHOUT_CHANGES: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force == 'true' }}
 
-      - name: Update chart version
+      - name: Resolve chart version
         id: version
         run: |
           tag_prefix="${{ matrix.chart }}-"
-          next_tag="${{ steps.next-tag.outputs.new_tag }}"
-          version="${next_tag#${tag_prefix}}"
+          if [[ "${{ matrix.chart }}" == "ingress-nginx" ]]; then
+            version=$(python scripts/resolve_ingress_nginx_release_version.py \
+              "charts/ingress-nginx/Chart.yaml" \
+              --tag-prefix "$tag_prefix")
+          else
+            next_tag="${{ steps.next-tag.outputs.new_tag }}"
+            version="${next_tag#${tag_prefix}}"
 
-          if [[ -z "$version" || "$version" == "$next_tag" ]]; then
-            echo "Failed to determine version from tag: $next_tag" >&2
-            exit 1
+            if [[ -z "$version" || "$version" == "$next_tag" ]]; then
+              echo "Failed to determine version from tag: $next_tag" >&2
+              exit 1
+            fi
+
+            chart_file="charts/${{ matrix.chart }}/Chart.yaml"
+            backup_file="${chart_file}.bak"
+
+            sed -i.bak -E "s/^version:[[:space:]]*.*/version: \"$version\"/" "$chart_file"
+
+            if [[ ! -f "$chart_file" || ! -s "$chart_file" ]]; then
+              echo "Failed to update version in $chart_file" >&2
+              mv "$backup_file" "$chart_file"
+              exit 1
+            fi
+
+            rm -f "$backup_file"
           fi
 
-          chart_file="charts/${{ matrix.chart }}/Chart.yaml"
-          backup_file="${chart_file}.bak"
-
-          sed -i.bak -E "s/^version:[[:space:]]*.*/version: \"$version\"/" "$chart_file"
-
-          if [[ ! -f "$chart_file" || ! -s "$chart_file" ]]; then
-            echo "Failed to update version in $chart_file" >&2
-            mv "$backup_file" "$chart_file"
-            exit 1
-          fi
-
-          rm -f "$backup_file"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Install chart-releaser

--- a/scripts/resolve_ingress_nginx_release_version.py
+++ b/scripts/resolve_ingress_nginx_release_version.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Resolve the committed ingress-nginx chart version for publication."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from functools import total_ordering
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_CHART_FILE = Path("charts/ingress-nginx/Chart.yaml")
+DEFAULT_TAG_PREFIX = "ingress-nginx-"
+PLACEHOLDER_VERSION = "0.0.0-a.placeholder"
+
+VERSION_LINE = re.compile(
+    r"""^\s*version:\s*
+        (?P<quote>["']?)
+        (?P<version>[^"'#\s]+)
+        (?P=quote)
+        \s*(?:\#.*)?$
+    """,
+    re.VERBOSE,
+)
+SEMVER = re.compile(
+    r"""^(?P<major>0|[1-9]\d*)
+        \.(?P<minor>0|[1-9]\d*)
+        \.(?P<patch>0|[1-9]\d*)
+        (?:-(?P<prerelease>
+            (?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)
+            (?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*
+        ))?
+        (?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?
+        $
+    """,
+    re.VERBOSE,
+)
+
+
+class ReleaseVersionError(ValueError):
+    """Raised when ingress-nginx cannot be safely published."""
+
+
+@total_ordering
+class SemVer:
+    """A minimal SemVer 2.0 value with precedence comparison."""
+
+    def __init__(self, value: str) -> None:
+        """Parse ``value`` as SemVer 2.0."""
+        match = SEMVER.fullmatch(value)
+        if match is None:
+            raise ReleaseVersionError(
+                f"{value!r} is not a valid semantic version"
+            )
+
+        self.value = value
+        self.core = tuple(
+            int(match.group(component))
+            for component in ("major", "minor", "patch")
+        )
+        prerelease = match.group("prerelease")
+        self.prerelease = (
+            tuple(prerelease.split(".")) if prerelease is not None else None
+        )
+
+    def __eq__(self, other: object) -> bool:
+        """Return whether two versions have equal SemVer precedence."""
+        if not isinstance(other, SemVer):
+            return NotImplemented
+        return self.core == other.core and self.prerelease == other.prerelease
+
+    def __lt__(self, other: object) -> bool:
+        """Return whether this version has lower SemVer precedence."""
+        if not isinstance(other, SemVer):
+            return NotImplemented
+        if self.core != other.core:
+            return self.core < other.core
+        if self.prerelease is None:
+            return False
+        if other.prerelease is None:
+            return True
+
+        for left, right in zip(self.prerelease, other.prerelease):
+            if left == right:
+                continue
+            left_numeric = left.isdigit()
+            right_numeric = right.isdigit()
+            if left_numeric and right_numeric:
+                return int(left) < int(right)
+            if left_numeric != right_numeric:
+                return left_numeric
+            return left < right
+        return len(self.prerelease) < len(other.prerelease)
+
+
+def read_chart_version(chart_file: Path) -> str:
+    """Read the top-level version field from a Helm Chart.yaml file."""
+    for line in chart_file.read_text(encoding="utf-8").splitlines():
+        match = VERSION_LINE.fullmatch(line)
+        if match is not None:
+            return match.group("version")
+    raise ReleaseVersionError(f"{chart_file} has no readable version field")
+
+
+def list_published_versions(repository: Path, tag_prefix: str) -> list[str]:
+    """Return versions from all Git tags matching ``tag_prefix``."""
+    result = subprocess.run(
+        ["git", "tag", "--list", f"{tag_prefix}*"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        tag.removeprefix(tag_prefix)
+        for tag in result.stdout.splitlines()
+        if tag
+    ]
+
+
+def resolve_release_version(
+    chart_version: str, published_versions: Iterable[str]
+) -> str:
+    """Validate and return the committed ingress-nginx chart version."""
+    if chart_version == PLACEHOLDER_VERSION:
+        raise ReleaseVersionError(
+            "ingress-nginx must declare an explicit release version"
+        )
+    candidate = SemVer(chart_version)
+    published = [SemVer(version) for version in published_versions]
+    if not published:
+        return chart_version
+
+    if candidate in published:
+        raise ReleaseVersionError(
+            f"ingress-nginx-{chart_version} is already published"
+        )
+
+    latest = max(published)
+    if candidate < latest:
+        raise ReleaseVersionError(
+            f"ingress-nginx-{chart_version} is older than the latest "
+            f"published tag ingress-nginx-{latest.value}"
+        )
+    return chart_version
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate the committed ingress-nginx chart version against "
+            "published chart tags."
+        )
+    )
+    parser.add_argument(
+        "chart_file",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_CHART_FILE,
+    )
+    parser.add_argument(
+        "--tag-prefix",
+        default=DEFAULT_TAG_PREFIX,
+    )
+    parser.add_argument(
+        "--repository",
+        type=Path,
+        default=Path.cwd(),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Validate and print the ingress-nginx version to publish."""
+    args = parse_args()
+    try:
+        chart_version = read_chart_version(args.chart_file)
+        published_versions = list_published_versions(
+            args.repository, args.tag_prefix
+        )
+        print(resolve_release_version(chart_version, published_versions))
+    except (
+        OSError,
+        ReleaseVersionError,
+        subprocess.CalledProcessError,
+    ) as exc:
+        print(f"Unable to publish ingress-nginx: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ingress_nginx_release_version.py
+++ b/tests/test_ingress_nginx_release_version.py
@@ -1,0 +1,98 @@
+"""Tests for ingress-nginx-specific chart release versioning."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+MODULE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "resolve_ingress_nginx_release_version.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "resolve_ingress_nginx_release_version", MODULE_PATH
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+ReleaseVersionError = MODULE.ReleaseVersionError
+SemVer = MODULE.SemVer
+read_chart_version = MODULE.read_chart_version
+resolve_release_version = MODULE.resolve_release_version
+
+
+def test_allows_009_after_008() -> None:
+    """Deleting the accidental 1.0.0 tag leaves the 0.0.9 path open."""
+    assert resolve_release_version("0.0.9", ["0.0.8"]) == "0.0.9"
+
+
+def test_rejects_009_while_100_exists() -> None:
+    """The accidental 1.0.0 tag must block an older 0.0.9 release."""
+    with pytest.raises(ReleaseVersionError, match="older than.*1.0.0"):
+        resolve_release_version("0.0.9", ["0.0.8", "1.0.0"])
+
+
+def test_rejects_duplicate_release() -> None:
+    """An existing tag must not be silently reused."""
+    with pytest.raises(ReleaseVersionError, match="already published"):
+        resolve_release_version("1.0.0", ["0.0.8", "1.0.0"])
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["1", "1.0", "01.0.0", "1.0.0-"],
+)
+def test_rejects_malformed_versions(version: str) -> None:
+    """Only valid SemVer values can be published."""
+    with pytest.raises(ReleaseVersionError, match="semantic version"):
+        resolve_release_version(version, [])
+
+
+def test_rejects_placeholder_version() -> None:
+    """ingress-nginx must always carry its intended published version."""
+    with pytest.raises(ReleaseVersionError, match="explicit release version"):
+        resolve_release_version("0.0.0-a.placeholder", [])
+
+
+def test_semver_prerelease_precedence() -> None:
+    """Prerelease comparison follows SemVer rather than string ordering."""
+    assert SemVer("1.0.0-rc.10") > SemVer("1.0.0-rc.2")
+    assert SemVer("1.0.0") > SemVer("1.0.0-rc.10")
+
+
+def test_reads_quoted_chart_version(tmp_path: Path) -> None:
+    """Quoted Chart.yaml versions and trailing comments are supported."""
+    chart_file = tmp_path / "Chart.yaml"
+    chart_file.write_text(
+        'apiVersion: v2\nversion: "0.0.9" # release candidate\n',
+        encoding="utf-8",
+    )
+    assert read_chart_version(chart_file) == "0.0.9"
+
+
+def test_release_workflow_isolates_ingress_nginx() -> None:
+    """Other charts must retain the existing tag-and-rewrite behavior."""
+    workflow_path = Path(".github/workflows/release.yml")
+    workflow_text = workflow_path.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(workflow_text)
+    steps = workflow["jobs"]["release"]["steps"]
+
+    tag_step = next(step for step in steps if step.get("id") == "next-tag")
+    assert tag_step["if"] == "matrix.chart != 'ingress-nginx'"
+    assert tag_step["uses"].startswith("anothrNick/github-tag-action@")
+
+    version_step = next(step for step in steps if step.get("id") == "version")
+    version_script = version_step["run"]
+    ingress_branch, other_charts_branch = version_script.split(
+        "else\n", maxsplit=1
+    )
+    assert "resolve_ingress_nginx_release_version.py" in ingress_branch
+    assert "sed -i.bak" not in ingress_branch
+    assert "steps.next-tag.outputs.new_tag" in other_charts_branch
+    assert "sed -i.bak" in other_charts_branch


### PR DESCRIPTION
## Problem

The Helm chart release workflow uses `anothrNick/github-tag-action` to calculate chart versions.

Although `TAG_PREFIX` selects the relevant chart tag series, the action scans repository-wide commit history. An unrelated breaking change:

```text
feat(universal-chart)!: block public metrics ingress by default #major
```

was therefore included when publishing ingress-nginx. The action started from `ingress-nginx-0.0.8`, detected `#major`, and produced `ingress-nginx-1.0.0` instead of the expected patch release `0.0.9`.

The ingress-nginx source workflow correctly derived and committed `version: 0.0.9`, but the Helm release workflow ignored and overwrote it.

## Solution

Make the version committed in `charts/ingress-nginx/Chart.yaml` authoritative for ingress-nginx releases.

- Skip `anothrNick/github-tag-action` for ingress-nginx.
- Read the ingress-nginx version directly from `Chart.yaml`.
- Validate that the version:
  - is valid SemVer;
  - is not the placeholder version;
  - has not already been published;
  - is newer than all existing `ingress-nginx-*` tags.
- Package and publish ingress-nginx without rewriting its version.
- Preserve the existing tag-action and publish-time versioning behavior for every other chart.

This change is intentionally scoped to ingress-nginx. It does not alter conventional-commit versioning for other charts.

## Recovery behavior

The validator prevents `0.0.9` from being published while the accidental `ingress-nginx-1.0.0` tag exists.

If `1.0.0` is manually removed from the GitHub release, Git tag, Helm index, and GHCR, the workflow can be dispatched again. It will publish the committed `0.0.9` version because `0.0.8` will once again be the latest ingress-nginx tag.

Cleanup of the existing `1.0.0` artifacts is not included in this PR.

## Source workflow alignment

The companion `ingress-nginx-nes` workflow documentation is updated to reflect that the version written into the helm-charts PR is authoritative and validated rather than overwritten.

The source workflow continues deriving the next ingress-nginx chart version from published `ingress-nginx-*` tags.

## Validation

- Added focused tests covering:
  - allowing `0.0.9` after `0.0.8`;
  - rejecting `0.0.9` while `1.0.0` exists;
  - duplicate, placeholder, and malformed versions;
  - SemVer prerelease ordering;
  - ingress-nginx workflow isolation;
  - preservation of existing versioning for other charts.
- Full test suite: 161 passed
- Focused release-version tests: 11 passed
- Full pre-commit suite: passed
- GitHub Actions workflow linting: passed