### PR TITLE
feat(universal-chart): add availability scheduling preset

### DIFF
--- a/charts/universal-chart/README.md
+++ b/charts/universal-chart/README.md
@@ -15,6 +15,50 @@ of helpful extra features:
 
 TODO: Explain how those work better
 
+## Availability scheduling
+
+The availability preset spreads matching pods across zones and nodes. It uses
+the standard `topology.kubernetes.io/zone` and `kubernetes.io/hostname` labels
+rather than a Karpenter-specific zone label.
+
+Preferred mode is the default because it won't block scheduling when capacity
+is tight:
+
+```yaml
+availability:
+  enabled: true
+  mode: preferred
+```
+
+Both constraints use `ScheduleAnyway`. The scheduler favors a different zone
+and node, but it can still place a pod when the cluster has limited capacity.
+
+Strict mode changes both constraints to `DoNotSchedule`:
+
+```yaml
+availability:
+  enabled: true
+  mode: strict
+```
+
+Use strict mode only when reduced availability is worse than delayed
+deployment. A pod remains Pending if the scheduler cannot satisfy both the zone
+and hostname constraints. This can stall a rollout during a zone outage or
+while the cluster waits for more nodes.
+
+The preset owns the zone and hostname constraints while it is enabled. The
+chart keeps custom constraints that use other topology keys, but drops raw zone
+or hostname constraints to avoid duplicate rules. Disable the preset when you
+need full control through `topologySpreadConstraints`.
+
+The legacy `spread_azs` value remains supported. It now uses
+`topology.kubernetes.io/zone`; new applications should use the availability
+preset when they also need node-level spreading.
+
+See the
+[Kubernetes topology spread documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+for the scheduler's full constraint behavior.
+
 ## Using The Chart
 
 Normally, you're going to want to distribute this chart via ArgoCD as an
@@ -176,6 +220,9 @@ helm template my-release . \
 | autoscaling.minReplicas | int | `1` | miminum number of replicas to run |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | If CPU utilization of replicas exceeds this percentage of requested CPU, start a new replica |
 | autoscaling.targetMemoryUtilizationPercentage | string | `nil` | If Memory utilization of replicas exceeds this percentage of requested Memory, start a new replica |
+| availability | object | `{"enabled":false,"mode":"preferred"}` | Spread replicas across availability zones and nodes. The preferred mode asks the scheduler to spread pods but still permits placement when capacity is limited. Strict mode leaves pods Pending rather than violate either rule. When enabled, this preset owns the `topology.kubernetes.io/zone` and `kubernetes.io/hostname` constraints; other custom constraints are preserved. More information: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
+| availability.enabled | bool | `false` | Whether to add the zone and hostname availability constraints. |
+| availability.mode | string | `"preferred"` | Scheduling mode. Use `preferred` to favor availability without blocking placement, or `strict` to require both constraints. |
 | awsEnvSecrets.env_secret_name | string | `"aws-env"` | name of secret to store AWS secretmanager values within |
 | awsEnvSecrets.externalSecret.secretPath | string | `""` | secret path |
 | awsEnvSecrets.externalSecret.secretStoreRef.kind | string | `"SecretStore"` | Is the store in this namespace or cluster-wide? |
@@ -268,12 +315,12 @@ helm template my-release . \
 | serviceMonitor.enabled | bool | `false` | Whether to create a ServiceMonitor resource. |
 | serviceMonitor.interval | string | `nil` | Optional scrape interval (in seconds). When null, the operator default is used. |
 | serviceMonitor.path | string | `"/metrics"` | HTTP path to scrape for metrics. Must start with "/". |
-| spread_azs | boolean | `false` | Add a topology spread rule across Karpenter availability zones. |
+| spread_azs | boolean | `false` | Add a preferred topology spread rule across availability zones. Kept for backward compatibility; prefer `availability.enabled` for new apps. |
 | spread_spot | boolean | `false` | Add a topology spread rule across Karpenter capacity types (spot vs on-demand). |
 | startupProbe | string | `nil` | Configure a startup probe to check if the application has started successfully. The startup probe is used to give the application more time to start up before the liveness probe takes over. This is especially useful for applications that take a long time to initialize. Once the startup probe succeeds once, Kubernetes will stop using it and switch to the liveness probe for ongoing health checks. More information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ Example configuration:   startupProbe:     httpGet:       path: /diagnostics/health       port: http     periodSeconds: 5     failureThreshold: 60 |
 | terminationGracePeriodSeconds | string | `nil` | Override the default termination grace period (in seconds). When null, the Kubernetes default of 30 seconds is used. Maximum allowed is 900 (15 minutes). |
 | tolerations | list | `[]` | List of taints these pods should tolerate. Normally this should be an empty list |
-| topologySpreadConstraints | list | `[{"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"}]` | When deploying with multiple replicas, spread pods around using these rules. The default is to spread pods evenly among the Availability Zones defined in the cluster. With a Karpenter-managed EKS cluster (like HeroDevs uses), there will usually be 3 AZs in a region where a cluster is deployed. If a constraint omits labelSelector, the chart injects selector labels. |
+| topologySpreadConstraints | list | `[{"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"}]` | When deploying with multiple replicas, spread pods around using these rules. The default is to spread pods evenly among the Availability Zones defined in the cluster. With a Karpenter-managed EKS cluster (like HeroDevs uses), there will usually be 3 AZs in a region where a cluster is deployed. If a constraint omits labelSelector, the chart injects selector labels. When the availability preset is enabled, it replaces custom zone and hostname constraints so each topology key appears only once. |
 | volumeMounts | list | `[]` | Additional volumes to mount |
 | volumes | list | `[]` | Additional volumes to create |
 

--- a/charts/universal-chart/README.md.gotmpl
+++ b/charts/universal-chart/README.md.gotmpl
@@ -14,6 +14,50 @@ of helpful extra features:
 
 TODO: Explain how those work better
 
+## Availability scheduling
+
+The availability preset spreads matching pods across zones and nodes. It uses
+the standard `topology.kubernetes.io/zone` and `kubernetes.io/hostname` labels
+rather than a Karpenter-specific zone label.
+
+Preferred mode is the default because it won't block scheduling when capacity
+is tight:
+
+```yaml
+availability:
+  enabled: true
+  mode: preferred
+```
+
+Both constraints use `ScheduleAnyway`. The scheduler favors a different zone
+and node, but it can still place a pod when the cluster has limited capacity.
+
+Strict mode changes both constraints to `DoNotSchedule`:
+
+```yaml
+availability:
+  enabled: true
+  mode: strict
+```
+
+Use strict mode only when reduced availability is worse than delayed
+deployment. A pod remains Pending if the scheduler cannot satisfy both the zone
+and hostname constraints. This can stall a rollout during a zone outage or
+while the cluster waits for more nodes.
+
+The preset owns the zone and hostname constraints while it is enabled. The
+chart keeps custom constraints that use other topology keys, but drops raw zone
+or hostname constraints to avoid duplicate rules. Disable the preset when you
+need full control through `topologySpreadConstraints`.
+
+The legacy `spread_azs` value remains supported. It now uses
+`topology.kubernetes.io/zone`; new applications should use the availability
+preset when they also need node-level spreading.
+
+See the
+[Kubernetes topology spread documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+for the scheduler's full constraint behavior.
+
 ## Using The Chart
 
 Normally, you're going to want to distribute this chart via ArgoCD as an

--- a/charts/universal-chart/templates/deployment.yaml
+++ b/charts/universal-chart/templates/deployment.yaml
@@ -184,17 +184,30 @@ spec:
       {{- $selectorLabels := include "universal-chart.selectorLabels" . | fromYaml }}
       {{- $defaultLabelSelector := dict "matchLabels" $selectorLabels }}
       {{- $topologySpreadConstraints := list }}
+      {{- $topologyKeys := list }}
+      {{- $availabilityTopologyKeys := list "topology.kubernetes.io/zone" "kubernetes.io/hostname" }}
+      {{- if .Values.availability.enabled }}
+      {{- $whenUnsatisfiable := ternary "DoNotSchedule" "ScheduleAnyway" (eq .Values.availability.mode "strict") }}
+      {{- range $availabilityTopologyKeys }}
+      {{- $topologySpreadConstraints = append $topologySpreadConstraints (dict "maxSkew" 1 "topologyKey" . "whenUnsatisfiable" $whenUnsatisfiable "labelSelector" $defaultLabelSelector) }}
+      {{- $topologyKeys = append $topologyKeys . }}
+      {{- end }}
+      {{- end }}
       {{- range .Values.topologySpreadConstraints }}
       {{- $constraint := . }}
       {{- if not (hasKey $constraint "labelSelector") }}
       {{- $constraint = merge $constraint (dict "labelSelector" $defaultLabelSelector) }}
       {{- end }}
+      {{- if not (and $.Values.availability.enabled (has $constraint.topologyKey $availabilityTopologyKeys)) }}
       {{- $topologySpreadConstraints = append $topologySpreadConstraints $constraint }}
+      {{- $topologyKeys = append $topologyKeys $constraint.topologyKey }}
       {{- end }}
-      {{- if .Values.spread_azs }}
-      {{- $topologySpreadConstraints = append $topologySpreadConstraints (dict "maxSkew" 1 "topologyKey" "karpenter.sh/zone" "whenUnsatisfiable" "ScheduleAnyway" "labelSelector" $defaultLabelSelector) }}
       {{- end }}
-      {{- if .Values.spread_spot }}
+      {{- if and .Values.spread_azs (not (has "topology.kubernetes.io/zone" $topologyKeys)) }}
+      {{- $topologySpreadConstraints = append $topologySpreadConstraints (dict "maxSkew" 1 "topologyKey" "topology.kubernetes.io/zone" "whenUnsatisfiable" "ScheduleAnyway" "labelSelector" $defaultLabelSelector) }}
+      {{- $topologyKeys = append $topologyKeys "topology.kubernetes.io/zone" }}
+      {{- end }}
+      {{- if and .Values.spread_spot (not (has "karpenter.sh/capacity-type" $topologyKeys)) }}
       {{- $topologySpreadConstraints = append $topologySpreadConstraints (dict "maxSkew" 1 "topologyKey" "karpenter.sh/capacity-type" "whenUnsatisfiable" "ScheduleAnyway" "labelSelector" $defaultLabelSelector) }}
       {{- end }}
       {{- with $topologySpreadConstraints }}

--- a/charts/universal-chart/values.schema.json
+++ b/charts/universal-chart/values.schema.json
@@ -185,6 +185,22 @@
         }
       }
     },
+    "availability": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "preferred",
+            "strict"
+          ]
+        }
+      }
+    },
     "spread_azs": {
       "type": "boolean"
     },

--- a/charts/universal-chart/values.yaml
+++ b/charts/universal-chart/values.yaml
@@ -805,7 +805,33 @@ tolerations: []
 # More info at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
-# -- (boolean) Add a topology spread rule across Karpenter availability zones.
+# @schema
+# type: object
+# additionalProperties: false
+# properties:
+#   enabled:
+#     type: boolean
+#   mode:
+#     type: string
+#     enum:
+#       - preferred
+#       - strict
+# @schema
+# -- Spread replicas across availability zones and nodes. The preferred mode
+# asks the scheduler to spread pods but still permits placement when capacity is
+# limited. Strict mode leaves pods Pending rather than violate either rule.
+# When enabled, this preset owns the `topology.kubernetes.io/zone` and
+# `kubernetes.io/hostname` constraints; other custom constraints are preserved.
+# More information: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+availability:
+  # -- Whether to add the zone and hostname availability constraints.
+  enabled: false
+  # -- Scheduling mode. Use `preferred` to favor availability without blocking
+  # placement, or `strict` to require both constraints.
+  mode: preferred
+
+# -- (boolean) Add a preferred topology spread rule across availability zones.
+# Kept for backward compatibility; prefer `availability.enabled` for new apps.
 spread_azs: false
 
 # -- (boolean) Add a topology spread rule across Karpenter capacity types
@@ -816,7 +842,9 @@ spread_spot: false
 # rules. The default is to spread pods evenly among the Availability Zones
 # defined in the cluster. With a Karpenter-managed EKS cluster (like HeroDevs
 # uses), there will usually be 3 AZs in a region where a cluster is deployed.
-# If a constraint omits labelSelector, the chart injects selector labels.
+# If a constraint omits labelSelector, the chart injects selector labels. When
+# the availability preset is enabled, it replaces custom zone and hostname
+# constraints so each topology key appears only once.
 topologySpreadConstraints:
   - maxSkew: 1
     topologyKey: topology.kubernetes.io/zone

--- a/tests/fixtures/universal-chart/availability-preferred-values.golden.yaml
+++ b/tests/fixtures/universal-chart/availability-preferred-values.golden.yaml
@@ -78,3 +78,10 @@ spec:
           maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: ScheduleAnyway
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: universal-chart
+              app.kubernetes.io/name: universal-chart
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway

--- a/tests/fixtures/universal-chart/availability-preferred-values.yaml
+++ b/tests/fixtures/universal-chart/availability-preferred-values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: ghcr.io/example/app
+  tag: "1.2.3"
+replicaCount: 3
+availability:
+  enabled: true
+  mode: preferred

--- a/tests/fixtures/universal-chart/availability-strict-values.golden.yaml
+++ b/tests/fixtures/universal-chart/availability-strict-values.golden.yaml
@@ -77,4 +77,11 @@ spec:
               app.kubernetes.io/name: universal-chart
           maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: universal-chart
+              app.kubernetes.io/name: universal-chart
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule

--- a/tests/fixtures/universal-chart/availability-strict-values.yaml
+++ b/tests/fixtures/universal-chart/availability-strict-values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: ghcr.io/example/app
+  tag: "1.2.3"
+replicaCount: 3
+availability:
+  enabled: true
+  mode: strict

--- a/tests/fixtures/universal-chart/topology-spread-both-values.golden.yaml
+++ b/tests/fixtures/universal-chart/topology-spread-both-values.golden.yaml
@@ -83,12 +83,5 @@ spec:
               app.kubernetes.io/instance: universal-chart
               app.kubernetes.io/name: universal-chart
           maxSkew: 1
-          topologyKey: karpenter.sh/zone
-          whenUnsatisfiable: ScheduleAnyway
-        - labelSelector:
-            matchLabels:
-              app.kubernetes.io/instance: universal-chart
-              app.kubernetes.io/name: universal-chart
-          maxSkew: 1
           topologyKey: karpenter.sh/capacity-type
           whenUnsatisfiable: ScheduleAnyway

--- a/tests/test_universal_chart_scheduling.py
+++ b/tests/test_universal_chart_scheduling.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 import pytest
 
 from .chart_test_utils import render_chart
@@ -9,12 +11,29 @@ from .conftest import HelmTemplateError
 from .universal_chart_test_utils import CHART, render_manifest
 
 
+def _topology_constraints(
+    helm_runner,
+    values: Mapping[str, object] | None = None,
+) -> list[dict[str, object]]:
+    """Render topology spread constraints from the Deployment."""
+
+    deployment = render_manifest(
+        helm_runner,
+        "Deployment",
+        values=values,
+    )
+    return deployment["spec"]["template"]["spec"].get(
+        "topologySpreadConstraints",
+        [],
+    )
+
+
 @pytest.mark.parametrize(
     ("value", "topology_key"),
     [
         pytest.param(
             {"spread_azs": True},
-            "karpenter.sh/zone",
+            "topology.kubernetes.io/zone",
             id="availability-zone",
         ),
         pytest.param(
@@ -29,19 +48,28 @@ def test_spread_toggle_appends_topology_constraint(
     value: dict[str, bool],
     topology_key: str,
 ) -> None:
-    """Add the requested topology spread constraint."""
+    """Keep legacy spread toggles working without duplicate constraints."""
 
-    deployment = render_manifest(
-        helm_runner,
-        "Deployment",
-        values=value,
-    )
-    constraints = deployment["spec"]["template"]["spec"].get(
-        "topologySpreadConstraints",
-        [],
-    )
+    constraints = _topology_constraints(helm_runner, value)
 
     assert any(item.get("topologyKey") == topology_key for item in constraints)
+    assert (
+        sum(item.get("topologyKey") == topology_key for item in constraints)
+        == 1
+    )
+
+
+def test_spread_azs_does_not_emit_karpenter_zone(helm_runner) -> None:
+    """Use the standard Kubernetes zone label for the legacy shortcut."""
+
+    constraints = _topology_constraints(
+        helm_runner,
+        {"spread_azs": True},
+    )
+
+    assert all(
+        item.get("topologyKey") != "karpenter.sh/zone" for item in constraints
+    )
 
 
 def test_spread_topology_defaults_do_not_include_extra_spreads(
@@ -49,17 +77,155 @@ def test_spread_topology_defaults_do_not_include_extra_spreads(
 ) -> None:
     """Keep optional topology constraints disabled by default."""
 
-    deployment = render_manifest(helm_runner, "Deployment")
-    constraints = deployment["spec"]["template"]["spec"].get(
-        "topologySpreadConstraints",
-        [],
-    )
+    constraints = _topology_constraints(helm_runner)
 
     assert all(
         item.get("topologyKey")
         not in {"karpenter.sh/zone", "karpenter.sh/capacity-type"}
         for item in constraints
     )
+
+
+@pytest.mark.parametrize("replica_count", [1, 3])
+@pytest.mark.parametrize(
+    ("mode", "when_unsatisfiable"),
+    [
+        pytest.param("preferred", "ScheduleAnyway", id="preferred"),
+        pytest.param("strict", "DoNotSchedule", id="strict"),
+    ],
+)
+def test_availability_preset_spreads_across_zones_and_nodes(
+    helm_runner,
+    replica_count: int,
+    mode: str,
+    when_unsatisfiable: str,
+) -> None:
+    """Render valid availability constraints for any replica count."""
+
+    constraints = _topology_constraints(
+        helm_runner,
+        {
+            "replicaCount": replica_count,
+            "availability": {"enabled": True, "mode": mode},
+        },
+    )
+    managed = {
+        item["topologyKey"]: item
+        for item in constraints
+        if item["topologyKey"]
+        in {"topology.kubernetes.io/zone", "kubernetes.io/hostname"}
+    }
+
+    assert set(managed) == {
+        "topology.kubernetes.io/zone",
+        "kubernetes.io/hostname",
+    }
+    for constraint in managed.values():
+        assert constraint["maxSkew"] == 1
+        assert constraint["whenUnsatisfiable"] == when_unsatisfiable
+        assert constraint["labelSelector"] == {
+            "matchLabels": {
+                "app.kubernetes.io/instance": CHART.release,
+                "app.kubernetes.io/name": "universal-chart",
+            }
+        }
+
+
+def test_availability_preset_preserves_unmanaged_custom_constraint(
+    helm_runner,
+) -> None:
+    """Keep custom topology keys and replace preset-owned duplicates."""
+
+    constraints = _topology_constraints(
+        helm_runner,
+        {
+            "availability": {"enabled": True, "mode": "strict"},
+            "topologySpreadConstraints": [
+                {
+                    "maxSkew": 2,
+                    "topologyKey": "topology.kubernetes.io/zone",
+                    "whenUnsatisfiable": "ScheduleAnyway",
+                },
+                {
+                    "maxSkew": 2,
+                    "topologyKey": "kubernetes.io/hostname",
+                    "whenUnsatisfiable": "ScheduleAnyway",
+                },
+                {
+                    "maxSkew": 1,
+                    "topologyKey": "rack.example.com/name",
+                    "whenUnsatisfiable": "ScheduleAnyway",
+                },
+            ],
+        },
+    )
+    by_key = {item["topologyKey"]: item for item in constraints}
+
+    assert len(constraints) == 3
+    assert by_key["topology.kubernetes.io/zone"]["whenUnsatisfiable"] == (
+        "DoNotSchedule"
+    )
+    assert by_key["kubernetes.io/hostname"]["whenUnsatisfiable"] == (
+        "DoNotSchedule"
+    )
+    assert by_key["rack.example.com/name"]["labelSelector"] == {
+        "matchLabels": {
+            "app.kubernetes.io/instance": CHART.release,
+            "app.kubernetes.io/name": "universal-chart",
+        }
+    }
+
+
+def test_custom_constraints_remain_authoritative_without_preset(
+    helm_runner,
+) -> None:
+    """Preserve raw scheduling behavior when the preset is disabled."""
+
+    custom_constraint = {
+        "maxSkew": 3,
+        "topologyKey": "topology.kubernetes.io/zone",
+        "whenUnsatisfiable": "DoNotSchedule",
+        "labelSelector": {"matchLabels": {"workload": "custom"}},
+    }
+    constraints = _topology_constraints(
+        helm_runner,
+        {"topologySpreadConstraints": [custom_constraint]},
+    )
+
+    assert constraints == [custom_constraint]
+
+
+def test_availability_preset_preserves_custom_affinity(helm_runner) -> None:
+    """Keep raw affinity rules alongside the availability preset."""
+
+    affinity = {
+        "nodeAffinity": {
+            "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                    "weight": 50,
+                    "preference": {
+                        "matchExpressions": [
+                            {
+                                "key": "node.example.com/pool",
+                                "operator": "In",
+                                "values": ["application"],
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+    }
+    deployment = render_manifest(
+        helm_runner,
+        "Deployment",
+        values={
+            "availability": {"enabled": True},
+            "affinity": affinity,
+        },
+    )
+
+    assert deployment["spec"]["template"]["spec"]["affinity"] == affinity
 
 
 def test_termination_grace_period_is_omitted_when_null(helm_runner) -> None:
@@ -107,3 +273,34 @@ def test_spread_values_reject_invalid_booleans(helm_runner) -> None:
     for key in ("spread_azs", "spread_spot"):
         with pytest.raises(HelmTemplateError):
             render_chart(helm_runner, CHART, values={key: "hero"})
+
+
+@pytest.mark.parametrize(
+    "availability",
+    [
+        pytest.param(
+            {"enabled": "hero", "mode": "preferred"},
+            id="enabled-is-not-boolean",
+        ),
+        pytest.param(
+            {"enabled": True, "mode": "sometimes"},
+            id="mode-is-not-supported",
+        ),
+        pytest.param(
+            {"enabled": True, "mode": "preferred", "extra": True},
+            id="unknown-property",
+        ),
+    ],
+)
+def test_availability_rejects_invalid_values(
+    helm_runner,
+    availability: dict[str, object],
+) -> None:
+    """Reject malformed availability preset values."""
+
+    with pytest.raises(HelmTemplateError):
+        render_chart(
+            helm_runner,
+            CHART,
+            values={"availability": availability},
+        )


### PR DESCRIPTION
## What changed

- fix `spread_azs` to use `topology.kubernetes.io/zone` and avoid duplicate legacy constraints
- add an opt-in availability preset that spreads pods across zones and nodes
- support explicit `preferred` (`ScheduleAnyway`) and `strict` (`DoNotSchedule`) modes
- preserve raw affinity and non-preset topology constraints
- document the strict-mode Pending-pod tradeoff

## Compatibility

This is a backward-compatible feature, so the commit uses `feat` without a breaking-change marker. Existing `spread_azs`, `spread_spot`, `affinity`, and `topologySpreadConstraints` values remain valid. The only legacy output change is the intended `spread_azs` fix: it no longer emits the invalid `karpenter.sh/zone` constraint or duplicates the chart default.

## Verification

- `make test` — 190 passed
- `pre-commit run --all-files` — passed

Closes #182