### PR TITLE
feat(universal-chart): add opt-in environment reloads

### DIFF
--- a/charts/universal-chart/README.md
+++ b/charts/universal-chart/README.md
@@ -59,6 +59,39 @@ See the
 [Kubernetes topology spread documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
 for the scheduler's full constraint behavior.
 
+## Reload environment inputs
+
+Kubernetes reads `envFrom` values when a container starts. Updating a Secret or
+ConfigMap doesn't change the environment of a running process. This includes a
+Secret update from External Secrets Operator.
+
+Enable `reloader` to ask
+[Stakater Reloader](https://docs.stakater.com/reloader/latest/) to roll the
+Deployment when one of its environment inputs changes:
+
+```yaml
+reloader:
+  enabled: true
+```
+
+The chart adds `reloader.stakater.com/auto: "true"` to the Deployment. Reloader
+then discovers the Secret and ConfigMap references in the rendered workload, so
+the chart doesn't maintain a separate list.
+
+Stakater Reloader must be installed in the cluster for the annotation to have
+an effect.
+
+This feature is disabled by default. If you already manage the annotation, the
+chart keeps your value:
+
+```yaml
+deployment:
+  annotations:
+    reloader.stakater.com/auto: "true"
+```
+
+An explicit annotation takes precedence even when `reloader.enabled` is true.
+
 ## Using The Chart
 
 Normally, you're going to want to distribute this chart via ArgoCD as an
@@ -282,6 +315,8 @@ helm template my-release . \
 | redis.metrics.prometheusRule.rules | list | `[{"alert":"RedisDown","annotations":{"description":"Redis(R) instance {{ \"{{ $labels.instance }}\" }} is down","summary":"Redis(R) instance {{ \"{{ $labels.instance }}\" }} down"},"expr":"redis_up{service=\"{{ template \"common.names.fullname\" . }}-metrics\"} == 0","for":"2m","labels":{"severity":"error"}},{"alert":"RedisMemoryHigh","annotations":{"description":"Redis(R) instance {{ \"{{ $labels.instance }}\" }} is using {{ \"{{ $value }}\" }}% of its available memory.\n","summary":"Redis(R) instance {{ \"{{ $labels.instance }}\" }} is using too much memory"},"expr":"redis_memory_used_bytes{service=\"{{ template \"common.names.fullname\" . }}-metrics\"} * 100 / redis_memory_max_bytes{service=\"{{ template \"common.names.fullname\" . }}-metrics\"} > 90\n","for":"2m","labels":{"severity":"error"}},{"alert":"RedisKeyEviction","annotations":{"description":"Redis(R) instance {{ \"{{ $labels.instance }}\" }} has evicted {{ \"{{ $value }}\" }} keys in the last 5 minutes.\n","summary":"Redis(R) instance {{ \"{{ $labels.instance }}\" }} has evicted keys"},"expr":"increase(redis_evicted_keys_total{service=\"{{ template \"common.names.fullname\" . }}-metrics\"}[5m]) > 0\n","for":"1s","labels":{"severity":"error"}}]` | default rules from the Bitnami chart :shrug: |
 | redis.replica | object | `{"resourcesPreset":"micro"}` | use presets for resource limits. See https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl |
 | redis.tls.enabled | bool | `false` | enable or disable TLS |
+| reloader | object | `{"enabled":false}` | Ask Stakater Reloader to restart the Deployment when a referenced Secret or ConfigMap changes. The chart adds `reloader.stakater.com/auto: "true"` and lets Reloader inspect the workload for references. This is disabled by default, so existing releases keep their current restart behavior. An explicit value in `deployment.annotations` takes precedence. |
+| reloader.enabled | bool | `false` | Whether to enable automatic Secret and ConfigMap reload discovery. |
 | replicaCount | int | `1` | set a fixed number of replicas in the deployment This value is ignored if autoscaling is enabled |
 | resources | object | `{}` | resource requests and limits. typically you can accept the values commented below, but ideally you'd run this in dev with some synthetic load and then either check on the monitoring values from Grafana or look at the Vertical Pod Autoscaler's recomendations via Goldilocks. |
 | revisionHistoryLimit | int | `3` | number of old ReplicaSets to retain for rollback |

--- a/charts/universal-chart/README.md.gotmpl
+++ b/charts/universal-chart/README.md.gotmpl
@@ -58,6 +58,39 @@ See the
 [Kubernetes topology spread documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
 for the scheduler's full constraint behavior.
 
+## Reload environment inputs
+
+Kubernetes reads `envFrom` values when a container starts. Updating a Secret or
+ConfigMap doesn't change the environment of a running process. This includes a
+Secret update from External Secrets Operator.
+
+Enable `reloader` to ask
+[Stakater Reloader](https://docs.stakater.com/reloader/latest/) to roll the
+Deployment when one of its environment inputs changes:
+
+```yaml
+reloader:
+  enabled: true
+```
+
+The chart adds `reloader.stakater.com/auto: "true"` to the Deployment. Reloader
+then discovers the Secret and ConfigMap references in the rendered workload, so
+the chart doesn't maintain a separate list.
+
+Stakater Reloader must be installed in the cluster for the annotation to have
+an effect.
+
+This feature is disabled by default. If you already manage the annotation, the
+chart keeps your value:
+
+```yaml
+deployment:
+  annotations:
+    reloader.stakater.com/auto: "true"
+```
+
+An explicit annotation takes precedence even when `reloader.enabled` is true.
+
 ## Using The Chart
 
 Normally, you're going to want to distribute this chart via ArgoCD as an

--- a/charts/universal-chart/templates/deployment.yaml
+++ b/charts/universal-chart/templates/deployment.yaml
@@ -1,10 +1,15 @@
 apiVersion: apps/v1
 kind: Deployment
+{{- $deploymentAnnotations := deepCopy (.Values.deployment.annotations | default dict) }}
+{{- $reloadAnnotation := "reloader.stakater.com/auto" }}
+{{- if and .Values.reloader.enabled (not (hasKey $deploymentAnnotations $reloadAnnotation)) }}
+{{- $_ := set $deploymentAnnotations $reloadAnnotation "true" }}
+{{- end }}
 metadata:
   name: {{ include "universal-chart.fullname" . }}
   labels:
     {{- include "universal-chart.labels" . | nindent 4 }}
-  {{- with .Values.deployment.annotations }}
+  {{- with $deploymentAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/universal-chart/values.schema.json
+++ b/charts/universal-chart/values.schema.json
@@ -42,6 +42,15 @@
         }
       }
     },
+    "reloader": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
     "serviceMonitor": {
       "properties": {
         "enabled": {

--- a/charts/universal-chart/values.yaml
+++ b/charts/universal-chart/values.yaml
@@ -41,6 +41,22 @@ deployment:
   annotations: {}
 
 # @schema
+# type: object
+# additionalProperties: false
+# properties:
+#   enabled:
+#     type: boolean
+# @schema
+# -- Ask Stakater Reloader to restart the Deployment when a referenced Secret
+# or ConfigMap changes. The chart adds `reloader.stakater.com/auto: "true"` and
+# lets Reloader inspect the workload for references. This is disabled by
+# default, so existing releases keep their current restart behavior. An
+# explicit value in `deployment.annotations` takes precedence.
+reloader:
+  # -- Whether to enable automatic Secret and ConfigMap reload discovery.
+  enabled: false
+
+# @schema
 # required: false
 # @schema
 # -- define init container(s) which will run before the "real" container

--- a/tests/fixtures/universal-chart/reloader-values.golden.yaml
+++ b/tests/fixtures/universal-chart/reloader-values.golden.yaml
@@ -1,0 +1,88 @@
+---
+# Source: universal-chart/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: universal-chart
+  labels:
+    helm.sh/chart: universal-chart-0.0.0-a.placeholder
+    app.kubernetes.io/name: universal-chart
+    app.kubernetes.io/instance: universal-chart
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: universal-chart/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: universal-chart
+  labels:
+    helm.sh/chart: universal-chart-0.0.0-a.placeholder
+    app.kubernetes.io/name: universal-chart
+    app.kubernetes.io/instance: universal-chart
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: universal-chart
+    app.kubernetes.io/instance: universal-chart
+---
+# Source: universal-chart/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: universal-chart
+  labels:
+    helm.sh/chart: universal-chart-0.0.0-a.placeholder
+    app.kubernetes.io/name: universal-chart
+    app.kubernetes.io/instance: universal-chart
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    example.com/owner: platform
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: universal-chart
+      app.kubernetes.io/instance: universal-chart
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: universal-chart-0.0.0-a.placeholder
+        app.kubernetes.io/name: universal-chart
+        app.kubernetes.io/instance: universal-chart
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: universal-chart
+      containers:
+        - name: universal-chart
+          env: &containerenv
+            # placeholder var so we can always make an env list
+            - name: REDIS_ENABLED
+              value: "false"
+          envFrom:
+            - secretRef:
+                name: database
+            - configMapRef:
+                name: application-config
+          image: "ghcr.io/example/app:1.2.3"
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: universal-chart
+              app.kubernetes.io/name: universal-chart
+          maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway

--- a/tests/fixtures/universal-chart/reloader-values.yaml
+++ b/tests/fixtures/universal-chart/reloader-values.yaml
@@ -1,0 +1,16 @@
+image:
+  repository: ghcr.io/example/app
+  tag: "1.2.3"
+
+reloader:
+  enabled: true
+
+extraEnvSecrets:
+  - database
+
+extraEnvConfigmaps:
+  - application-config
+
+deployment:
+  annotations:
+    example.com/owner: platform

--- a/tests/test_universal_chart_reloader.py
+++ b/tests/test_universal_chart_reloader.py
@@ -1,0 +1,129 @@
+"""Environment reload annotation tests for universal-chart."""
+
+from __future__ import annotations
+
+import pytest
+
+from .chart_test_utils import render_chart
+from .conftest import HelmTemplateError
+from .universal_chart_test_utils import CHART, render_manifest
+
+RELOAD_ANNOTATION = "reloader.stakater.com/auto"
+
+
+def _deployment_annotations(
+    helm_runner,
+    values: dict[str, object],
+) -> dict[str, str]:
+    """Render Deployment metadata annotations."""
+
+    deployment = render_manifest(
+        helm_runner,
+        "Deployment",
+        values=values,
+    )
+    return deployment["metadata"].get("annotations", {})
+
+
+def test_reloader_is_disabled_by_default(helm_runner) -> None:
+    """Keep existing environment inputs from changing rendered Deployments."""
+
+    annotations = _deployment_annotations(
+        helm_runner,
+        {
+            "awsEnvSecrets": {
+                "env_secret_name": "aws-env",
+                "externalSecret": {"secretPath": "apps/example"},
+            },
+            "extraEnvSecrets": ["database"],
+            "extraEnvConfigmaps": ["application-config"],
+        },
+    )
+
+    assert RELOAD_ANNOTATION not in annotations
+
+
+@pytest.mark.parametrize(
+    "input_values",
+    [
+        pytest.param({}, id="no-inputs"),
+        pytest.param({"extraEnvSecrets": ["database"]}, id="secret"),
+        pytest.param(
+            {"extraEnvConfigmaps": ["application-config"]},
+            id="configmap",
+        ),
+    ],
+)
+def test_reloader_enables_automatic_discovery(
+    helm_runner,
+    input_values: dict[str, object],
+) -> None:
+    """Let Reloader discover referenced Secrets and ConfigMaps."""
+
+    annotations = _deployment_annotations(
+        helm_runner,
+        {
+            "reloader": {"enabled": True},
+            **input_values,
+        },
+    )
+
+    assert annotations[RELOAD_ANNOTATION] == "true"
+
+
+def test_reloader_preserves_deployment_annotations(helm_runner) -> None:
+    """Add automatic discovery without dropping caller metadata."""
+
+    annotations = _deployment_annotations(
+        helm_runner,
+        {
+            "reloader": {"enabled": True},
+            "extraEnvSecrets": ["database"],
+            "extraEnvConfigmaps": ["application-config"],
+            "deployment": {
+                "annotations": {"example.com/owner": "platform"},
+            },
+        },
+    )
+
+    assert annotations == {
+        "example.com/owner": "platform",
+        RELOAD_ANNOTATION: "true",
+    }
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_explicit_reload_annotation_takes_precedence(
+    helm_runner,
+    enabled: bool,
+) -> None:
+    """Preserve the caller-managed setting in either mode."""
+
+    annotations = _deployment_annotations(
+        helm_runner,
+        {
+            "reloader": {"enabled": enabled},
+            "deployment": {
+                "annotations": {
+                    RELOAD_ANNOTATION: "false",
+                },
+            },
+        },
+    )
+
+    assert annotations[RELOAD_ANNOTATION] == "false"
+
+
+@pytest.mark.parametrize("enabled", ["true", 1, []])
+def test_reloader_rejects_non_boolean_enabled_values(
+    helm_runner,
+    enabled: object,
+) -> None:
+    """Reject values that Helm would otherwise coerce by truthiness."""
+
+    with pytest.raises(HelmTemplateError):
+        render_chart(
+            helm_runner,
+            CHART,
+            values={"reloader": {"enabled": enabled}},
+        )


### PR DESCRIPTION
## What changed

- add `reloader.enabled`, disabled by default
- add `reloader.stakater.com/auto: "true"` to the Deployment when enabled
- let Stakater Reloader discover referenced Secrets and ConfigMaps instead of maintaining target-name lists in the chart
- preserve an explicit caller-managed auto annotation and unrelated Deployment annotations
- add schema validation, focused tests, a golden fixture, and usage documentation

## Compatibility

This is an opt-in feature. Existing values render the same Deployment metadata, so the commit uses `feat` without a breaking-change marker. We can enable the switch by default later as part of the planned breaking release.

Automatic discovery also means future Secret and ConfigMap reference features do not need matching Reloader name-generation logic.

## Verification

- full test suite with network-dependent Helm setup skipped — 201 passed
- `pre-commit run --all-files` — passed

Closes #181