### PR TITLE
ci: verify generated Helm schemas

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,5 +69,8 @@ jobs:
         with:
           cache: true
 
+      - name: Verify generated Helm schema
+        run: pre-commit run helm-schema --all-files
+
       - name: Helm lint
         run: pre-commit run helmlint --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,20 @@ repos:
   ########################################
   # helm
   ########################################
+  # generate values.schema.json from the annotations in values.yaml
+  - repo: https://github.com/dadav/helm-schema
+    rev: 0.23.4
+    hooks:
+      - id: helm-schema
+        name: Check universal chart schema
+        args:
+          - --append-newline
+          - --skip-auto-generation=required
+          - --chart-search-root=charts/universal-chart
+          - --no-dependencies
+        files: ^charts/universal-chart/(Chart\.yaml|values\.yaml|values\.schema\.json)$
+        pass_filenames: false
+
   # helm lint
   - repo: https://github.com/gruntwork-io/pre-commit
     rev: v0.1.30

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -16,9 +16,15 @@ The generated chart `README.md` remains the source of truth for values docs,
 and `docs/reference.md` should stay as a symlink to that file.
 
 Schemas are generated from each chart's `values.yaml` annotations with
-helm-schema. Run `helm-schema -a -k required` to regenerate them. The
-`required` field is skipped because helm-schema otherwise assumes every value
-is required.
+helm-schema. Run `pre-commit run helm-schema --all-files` after changing those
+annotations. The first run updates a stale `values.schema.json` and exits
+nonzero because it changed the file. Review the result, then run the command
+again; a clean second run confirms that the schema is current.
+
+The hook pins helm-schema and runs it with `--append-newline`,
+`--skip-auto-generation=required`, and `--no-dependencies`. It currently
+targets `charts/universal-chart`, the only chart with a generated values
+schema.
 
 
 # Andre


### PR DESCRIPTION
## What changed

- add the upstream helm-schema pre-commit hook, pinned to `0.23.4`
- regenerate the universal chart schema with the same newline, required-field, and dependency options every time
- run that hook before Helm lint in the existing GitHub Actions job
- document the local two-pass workflow: the first run updates a stale schema, and the second confirms it is current

The hook is scoped to `charts/universal-chart` because that is currently the only chart with a generated `values.schema.json`. Changes to its `Chart.yaml`, `values.yaml`, or generated schema trigger the check.

## Verification

- clean schema check — passed
- intentionally stale schema — failed and regenerated the committed result as expected
- `pre-commit run --all-files` — passed
- `make test` — 214 passed, including Helm dependency builds