### PR TITLE
feat: autoscaling - horizontal & vertical support

### DIFF
--- a/charts/universal-chart/README.md
+++ b/charts/universal-chart/README.md
@@ -8,12 +8,57 @@ NES Universal Helm Chart
 
 ## Additional Information
 
-This is supposedly a universal helm chart for "simple" apps.  It has a couple
-of helpful extra features:
-* built-in support for loading env vars from an AWS Secret Manager secret
-* Bitnami redis chart
+`universal-chart` deploys application containers with standard Kubernetes
+workload, networking, secrets, observability, availability, and autoscaling
+primitives. The generated values reference below is the configuration source
+of truth. Task-focused guides are available in the
+[universal-chart documentation](https://github.com/neverendingsupport/helm-charts/tree/main/charts/universal-chart/docs).
 
-TODO: Explain how those work better
+## Autoscaling
+
+New HPA configurations use the stable Kubernetes `autoscaling/v2` interface
+under `autoscaling.horizontal`. CPU utilization requires a CPU request:
+
+```yaml
+image:
+  repository: ghcr.io/example/app
+  tag: "1.2.3"
+
+resources:
+  requests:
+    cpu: 100m
+
+autoscaling:
+  horizontal:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+```
+
+For an existing application, merge this section into its values to start VPA
+adoption in recommendation-only mode:
+
+```yaml
+autoscaling:
+  vertical:
+    enabled: true
+    updatePolicy:
+      updateMode: "Off"
+      minReplicas: 2
+```
+
+Read the
+[autoscaling guide](https://github.com/neverendingsupport/helm-charts/blob/main/charts/universal-chart/docs/autoscaling.md)
+before activating VPA or using Prometheus-backed HPA metrics. It covers
+prerequisites, safety ceilings, HPA/VPA conflicts, verification,
+troubleshooting, and rollback.
 
 ## Pin application images by digest
 
@@ -281,15 +326,30 @@ helm template my-release . \
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Select roughly specific nodes to run upon. This is similar to node selectors, but allows a bit more fuzziness and flexibility. More info at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity |
-| autoscaling | object | `{"annotations":{},"behavior":{},"enabled":false,"hpaScalingRules":[],"maxReplicas":10,"minReplicas":1,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null}` | section for configuring autoscaling. More information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/ |
-| autoscaling.annotations | object | `{}` | Additional annotations to add to the HorizontalPodAutoscaler metadata. |
-| autoscaling.behavior | object | `{}` | Optional HorizontalPodAutoscaler behavior defaults. |
-| autoscaling.enabled | bool | `false` | enable autoscaling |
-| autoscaling.hpaScalingRules | list | `[]` | Prometheus-backed external metric scaling rules. Each rule generates a Prometheus recording rule labeled `hpa_metric: "true"` and adds an External metric to the chart-managed HPA. Set `targetCPUUtilizationPercentage: null` and `targetMemoryUtilizationPercentage: null` for external-only scaling. |
-| autoscaling.maxReplicas | int | `10` | maximum number of replicas to run |
-| autoscaling.minReplicas | int | `1` | miminum number of replicas to run |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` | If CPU utilization of replicas exceeds this percentage of requested CPU, start a new replica |
-| autoscaling.targetMemoryUtilizationPercentage | string | `nil` | If Memory utilization of replicas exceeds this percentage of requested Memory, start a new replica |
+| autoscaling | object | `{"annotations":{},"behavior":{},"enabled":false,"horizontal":{},"hpaScalingRules":[],"maxReplicas":10,"minReplicas":1,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null,"vertical":{"annotations":{},"enabled":false,"resourcePolicy":{"containerPolicies":[{"containerName":"*","controlledResources":["cpu","memory"],"controlledValues":"RequestsOnly","maxAllowed":{},"minAllowed":{},"mode":"Auto"}]},"updatePolicy":{"minReplicas":2,"updateMode":"Off"}}}` | autoscaling configures horizontal and vertical pod autoscaling. Prefer `autoscaling.horizontal` for new HPA configurations. The legacy sibling HPA keys remain supported; an explicitly supplied horizontal key overrides its legacy equivalent. |
+| autoscaling.annotations | object | `{}` | annotations are the legacy HPA annotations. Prefer `horizontal.annotations`. |
+| autoscaling.behavior | object | `{}` | behavior is the legacy autoscaling/v2 HPA behavior. Prefer `horizontal.behavior`. |
+| autoscaling.enabled | bool | `false` | enabled is the legacy HPA switch. Prefer `horizontal.enabled`. |
+| autoscaling.horizontal | object | `{}` | horizontal is the stable autoscaling/v2 HorizontalPodAutoscaler configuration. Explicit keys override legacy sibling keys; omitted keys inherit them. |
+| autoscaling.hpaScalingRules | list | `[]` | hpaScalingRules are the legacy Prometheus-backed scaling rules. Prefer `horizontal.prometheusScalingRules`. |
+| autoscaling.maxReplicas | int | `10` | maxReplicas is the legacy HPA ceiling. Prefer `horizontal.maxReplicas`. |
+| autoscaling.minReplicas | int | `1` | minReplicas is the legacy HPA floor. Prefer `horizontal.minReplicas`. |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | targetCPUUtilizationPercentage is the legacy CPU utilization target. It requires `resources.requests.cpu`. |
+| autoscaling.targetMemoryUtilizationPercentage | string | `nil` | targetMemoryUtilizationPercentage is the legacy memory utilization target. It requires `resources.requests.memory`. |
+| autoscaling.vertical | object | `{"annotations":{},"enabled":false,"resourcePolicy":{"containerPolicies":[{"containerName":"*","controlledResources":["cpu","memory"],"controlledValues":"RequestsOnly","maxAllowed":{},"minAllowed":{},"mode":"Auto"}]},"updatePolicy":{"minReplicas":2,"updateMode":"Off"}}` | vertical configures VerticalPodAutoscaler. Enabling update mode `Off` creates recommendations without mutating pods. Active modes require a `maxAllowed` ceiling for every controlled resource. |
+| autoscaling.vertical.annotations | object | `{}` | annotations are added to VerticalPodAutoscaler metadata. |
+| autoscaling.vertical.enabled | bool | `false` | enabled creates an autoscaling.k8s.io/v1 VerticalPodAutoscaler. |
+| autoscaling.vertical.resourcePolicy | object | `{"containerPolicies":[{"containerName":"*","controlledResources":["cpu","memory"],"controlledValues":"RequestsOnly","maxAllowed":{},"minAllowed":{},"mode":"Auto"}]}` | resourcePolicy defines per-container recommendation and mutation boundaries. |
+| autoscaling.vertical.resourcePolicy.containerPolicies | list | `[{"containerName":"*","controlledResources":["cpu","memory"],"controlledValues":"RequestsOnly","maxAllowed":{},"minAllowed":{},"mode":"Auto"}]` | containerPolicies select controlled containers and resource bounds. |
+| autoscaling.vertical.resourcePolicy.containerPolicies[0] | object | `{"containerName":"*","controlledResources":["cpu","memory"],"controlledValues":"RequestsOnly","maxAllowed":{},"minAllowed":{},"mode":"Auto"}` | containerName selects all containers by default. |
+| autoscaling.vertical.resourcePolicy.containerPolicies[0].controlledResources | list | `["cpu","memory"]` | controlledResources limits VPA to CPU and memory requests. |
+| autoscaling.vertical.resourcePolicy.containerPolicies[0].controlledValues | string | `"RequestsOnly"` | controlledValues changes requests without changing limits. |
+| autoscaling.vertical.resourcePolicy.containerPolicies[0].maxAllowed | object | `{}` | maxAllowed sets required ceilings before activating VPA. |
+| autoscaling.vertical.resourcePolicy.containerPolicies[0].minAllowed | object | `{}` | minAllowed optionally sets resource recommendation floors. |
+| autoscaling.vertical.resourcePolicy.containerPolicies[0].mode | string | `"Auto"` | mode enables recommendations for the selected containers. |
+| autoscaling.vertical.updatePolicy | object | `{"minReplicas":2,"updateMode":"Off"}` | updatePolicy controls VPA mutation. `InPlaceOrRecreate` requires compatible cluster and VPA feature gates and may fall back to eviction. |
+| autoscaling.vertical.updatePolicy.minReplicas | int | `2` | minReplicas prevents active VPA from reducing available pods below this count during updates. |
+| autoscaling.vertical.updatePolicy.updateMode | string | `"Off"` | updateMode selects recommendation-only or active VPA behavior. |
 | availability | object | `{"enabled":false,"mode":"preferred"}` | Spread replicas across availability zones and nodes. The preferred mode asks the scheduler to spread pods but still permits placement when capacity is limited. Strict mode leaves pods Pending rather than violate either rule. When enabled, this preset owns the `topology.kubernetes.io/zone` and `kubernetes.io/hostname` constraints; other custom constraints are preserved. More information: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
 | availability.enabled | bool | `false` | Whether to add the zone and hostname availability constraints. |
 | availability.mode | string | `"preferred"` | Scheduling mode. Use `preferred` to favor availability without blocking placement, or `strict` to require both constraints. |
@@ -396,6 +456,3 @@ helm template my-release . \
 | topologySpreadConstraints | list | `[{"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"}]` | When deploying with multiple replicas, spread pods around using these rules. The default is to spread pods evenly among the Availability Zones defined in the cluster. With a Karpenter-managed EKS cluster (like HeroDevs uses), there will usually be 3 AZs in a region where a cluster is deployed. If a constraint omits labelSelector, the chart injects selector labels. When the availability preset is enabled, it replaces custom zone and hostname constraints so each topology key appears only once. |
 | volumeMounts | list | `[]` | Additional volumes to mount |
 | volumes | list | `[]` | Additional volumes to create |
-
-----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/universal-chart/README.md.gotmpl
+++ b/charts/universal-chart/README.md.gotmpl
@@ -7,12 +7,57 @@
 
 ## Additional Information
 
-This is supposedly a universal helm chart for "simple" apps.  It has a couple
-of helpful extra features:
-* built-in support for loading env vars from an AWS Secret Manager secret
-* Bitnami redis chart
+`universal-chart` deploys application containers with standard Kubernetes
+workload, networking, secrets, observability, availability, and autoscaling
+primitives. The generated values reference below is the configuration source
+of truth. Task-focused guides are available in the
+[universal-chart documentation](https://github.com/neverendingsupport/helm-charts/tree/main/charts/universal-chart/docs).
 
-TODO: Explain how those work better
+## Autoscaling
+
+New HPA configurations use the stable Kubernetes `autoscaling/v2` interface
+under `autoscaling.horizontal`. CPU utilization requires a CPU request:
+
+```yaml
+image:
+  repository: ghcr.io/example/app
+  tag: "1.2.3"
+
+resources:
+  requests:
+    cpu: 100m
+
+autoscaling:
+  horizontal:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+```
+
+For an existing application, merge this section into its values to start VPA
+adoption in recommendation-only mode:
+
+```yaml
+autoscaling:
+  vertical:
+    enabled: true
+    updatePolicy:
+      updateMode: "Off"
+      minReplicas: 2
+```
+
+Read the
+[autoscaling guide](https://github.com/neverendingsupport/helm-charts/blob/main/charts/universal-chart/docs/autoscaling.md)
+before activating VPA or using Prometheus-backed HPA metrics. It covers
+prerequisites, safety ceilings, HPA/VPA conflicts, verification,
+troubleshooting, and rollback.
 
 ## Pin application images by digest
 

--- a/charts/universal-chart/docs/autoscaling.md
+++ b/charts/universal-chart/docs/autoscaling.md
@@ -1,0 +1,382 @@
+# Configure pod autoscaling
+
+This guide helps application developers and Kubernetes operators configure
+horizontal and vertical pod autoscaling with `universal-chart`. Horizontal Pod
+Autoscaler (HPA) resources use the stable Kubernetes `autoscaling/v2` API.
+Vertical Pod Autoscaler (VPA) resources use the separately installed
+`autoscaling.k8s.io/v1` custom resource.
+
+## Choose an autoscaling mode
+
+The following table summarizes the supported operating modes.
+
+| Goal | HPA | VPA update mode | Use when |
+| --- | --- | --- | --- |
+| Fixed capacity | Disabled | Disabled | Replica and resource requirements are known and stable. |
+| Scale replica count | Enabled | Disabled or `Off` | Load changes horizontally and resource requests are already suitable. |
+| Collect resource recommendations | Optional | `Off` | You want sizing data without changing pods. |
+| Apply resource recommendations | Disabled | `Initial`, `Recreate`, or `InPlaceOrRecreate` | Resource requests need automated adjustment. |
+| Scale replicas and resources | Enabled | Active | HPA uses External, Object, Pods, or raw-value metrics that do not depend on VPA-managed utilization ratios. |
+
+The chart rejects an active VPA when an HPA Resource or ContainerResource
+metric uses `Utilization` for the same VPA-controlled resource. VPA changes the
+request that forms the denominator of utilization, so the two controllers
+would otherwise influence each other.
+
+## Check cluster prerequisites
+
+HPA is built into Kubernetes, but its metric APIs are separate:
+
+- Resource and ContainerResource utilization normally require Metrics Server
+  to provide `metrics.k8s.io`.
+- Object and Pods metrics require a custom metrics adapter that provides
+  `custom.metrics.k8s.io`.
+- External metrics require an adapter that provides
+  `external.metrics.k8s.io`.
+- Every container included in a Resource utilization metric must declare the
+  corresponding resource request. A metric supplied through
+  `horizontal.metrics` fails rendering when the primary container has no
+  matching request; a metric inherited from the legacy targets renders without
+  one, so audit those releases with `kubectl describe hpa`. Injected sidecars
+  remain the operator's responsibility in both cases.
+
+VPA requires the VPA custom resource definitions, recommender, admission
+controller, and updater to be installed by the platform team. This chart
+creates a VPA resource but does not install those cluster components.
+
+Run these read-only checks from any directory with `kubectl` configured for the
+target cluster:
+
+```bash
+kubectl api-resources --api-group=autoscaling
+kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes
+kubectl api-resources --api-group=autoscaling.k8s.io
+kubectl get deployments --all-namespaces \
+  -l app.kubernetes.io/name=vpa-recommender
+```
+
+The first command should list `horizontalpodautoscalers` in
+`autoscaling/v2`. The second should return node metrics when Metrics Server is
+available. The last two should list `verticalpodautoscalers` and the installed
+VPA recommender. Installation labels vary; if the final command returns no
+objects, ask the platform team for the VPA component namespace and labels.
+
+## Configure a CPU HPA
+
+Add the following complete minimal values to a new application, or merge the
+`resources` and `autoscaling` sections into existing values:
+
+```yaml
+image:
+  repository: ghcr.io/example/app
+  tag: "1.2.3"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+autoscaling:
+  horizontal:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+```
+
+`horizontal.metrics` accepts the native `autoscaling/v2` MetricSpec shapes:
+Resource, ContainerResource, External, Object, and Pods. Kubernetes calculates
+the desired replica count for every configured metric and uses the highest
+result.
+
+To set scale-up and scale-down behavior, use the native v2 behavior shape:
+
+```yaml
+autoscaling:
+  horizontal:
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 0
+        selectPolicy: Max
+        policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 60
+      scaleDown:
+        stabilizationWindowSeconds: 300
+        selectPolicy: Min
+        policies:
+          - type: Percent
+            value: 25
+            periodSeconds: 60
+```
+
+The optional `tolerance` field requires Kubernetes support for the
+`HPAConfigurableTolerance` feature. Omit it unless the platform team confirms
+that the target cluster enables the feature.
+
+## Scale from a Prometheus metric
+
+The chart can generate both a Prometheus recording rule and its matching HPA
+External metric:
+
+```yaml
+image:
+  repository: ghcr.io/example/app
+  tag: "1.2.3"
+
+prometheusRule:
+  additionalLabels:
+    release: kube-prometheus-stack
+
+autoscaling:
+  horizontal:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 20
+    metrics: []
+    prometheusScalingRules:
+      - name: example_queue_messages_ready
+        expr: |
+          sum(
+            example_queue_messages_ready{namespace="example"}
+          )
+        selector:
+          queue: default
+        target:
+          type: AverageValue
+          averageValue: "100"
+```
+
+The rule is labeled `hpa_metric: "true"`. A working configuration has this data
+path:
+
+1. The application exposes the source metric.
+2. Prometheus scrapes the metric and evaluates the generated recording rule.
+3. Prometheus Adapter discovers the `hpa_metric: "true"` series and publishes
+   it through `external.metrics.k8s.io`.
+4. The HPA controller reads the External metric and changes Deployment
+   replicas.
+
+The `prometheusRule.additionalLabels` values must match the Prometheus
+Operator's rule selector. The adapter must be configured to discover the
+`hpa_metric: "true"` label; this chart does not configure the adapter.
+
+Before rollout, set the shell variables to the release namespace and metric
+name, then verify every dependency:
+
+```bash
+NAMESPACE=example
+METRIC_NAME=example_queue_messages_ready
+
+kubectl api-resources --api-group=monitoring.coreos.com
+kubectl get prometheusrules -n "${NAMESPACE}"
+kubectl get --raw /apis/external.metrics.k8s.io/v1beta1
+kubectl get --raw \
+  "/apis/external.metrics.k8s.io/v1beta1/namespaces/${NAMESPACE}/${METRIC_NAME}"
+```
+
+Prometheus Operator discovery and adapter relist intervals can delay a new
+metric. If the last command returns `NotFound`, verify the recording series and
+adapter configuration before changing the HPA target.
+
+## Start VPA in recommendation-only mode
+
+Recommendation mode is the default adoption path. It does not change pod
+resources:
+
+```yaml
+image:
+  repository: ghcr.io/example/app
+  tag: "1.2.3"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+autoscaling:
+  vertical:
+    enabled: true
+    updatePolicy:
+      updateMode: "Off"
+      minReplicas: 2
+    resourcePolicy:
+      containerPolicies:
+        - containerName: "*"
+          mode: Auto
+          controlledResources:
+            - cpu
+            - memory
+          controlledValues: RequestsOnly
+          minAllowed: {}
+          maxAllowed: {}
+```
+
+The default `RequestsOnly` policy leaves limits unchanged. `RequestsAndLimits`
+asks VPA to scale limits proportionally with requests; select it only after
+confirming that behavior is suitable for the workload.
+
+## Activate VPA with resource ceilings
+
+Review recommendations across representative traffic and deployment cycles
+before selecting an active mode. Every active policy requires `maxAllowed` for
+each controlled resource:
+
+```yaml
+autoscaling:
+  vertical:
+    enabled: true
+    updatePolicy:
+      updateMode: Initial
+      minReplicas: 2
+    resourcePolicy:
+      containerPolicies:
+        - containerName: "*"
+          mode: Auto
+          controlledResources:
+            - cpu
+            - memory
+          controlledValues: RequestsOnly
+          minAllowed:
+            cpu: 50m
+            memory: 64Mi
+          maxAllowed:
+            cpu: "2"
+            memory: 2Gi
+```
+
+Choose the update mode deliberately:
+
+- `Initial` applies recommendations only when pods are created.
+- `Recreate` allows VPA to evict and recreate pods. Use a PodDisruptionBudget
+  and enough replicas to tolerate eviction.
+- `InPlaceOrRecreate` attempts an in-place resource update and may fall back to
+  eviction. It requires compatible VPA components and the Kubernetes
+  `InPlacePodVerticalScaling` feature. Confirm both with the platform team
+  before rollout.
+
+The chart does not support deprecated VPA mode `Auto` or direct `InPlace`.
+
+## Migrate legacy HPA values
+
+Legacy sibling keys under `autoscaling` remain supported:
+
+```yaml
+resources:
+  requests:
+    cpu: 100m
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+```
+
+Migrate by expressing the metric through the stable v2 interface:
+
+```yaml
+resources:
+  requests:
+    cpu: 100m
+
+autoscaling:
+  horizontal:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+```
+
+Precedence is evaluated per key:
+
+- An explicitly supplied `autoscaling.horizontal` key replaces its legacy
+  sibling.
+- An omitted horizontal key inherits the legacy value.
+- Explicit `metrics: []` suppresses legacy CPU and memory metrics.
+- Explicit `prometheusScalingRules: []` suppresses legacy
+  `hpaScalingRules`.
+- Effective Prometheus rules append External metrics to `horizontal.metrics`.
+
+This lets applications migrate one setting at a time. Remove legacy keys after
+the preferred configuration is complete.
+
+Validation is stricter on the new interface by design. Moving a CPU or memory
+target into `horizontal.metrics` starts requiring the matching
+`resources.requests` entry, so add the request in the same change that adopts
+the metric.
+
+## Verify the rollout
+
+Set the namespace and autoscaler resource name, then inspect controller status.
+With release name `example` and no name overrides, the default resource name is
+`example-universal-chart`. Use the name shown by the rendered HPA or VPA when
+the release sets `nameOverride` or `fullnameOverride`.
+
+```bash
+NAMESPACE=example
+AUTOSCALER_NAME=example-universal-chart
+
+kubectl get hpa -n "${NAMESPACE}" "${AUTOSCALER_NAME}"
+kubectl describe hpa -n "${NAMESPACE}" "${AUTOSCALER_NAME}"
+kubectl get vpa -n "${NAMESPACE}" "${AUTOSCALER_NAME}" -o yaml
+kubectl get events -n "${NAMESPACE}" \
+  --field-selector involvedObject.name="${AUTOSCALER_NAME}" \
+  --sort-by=.lastTimestamp
+```
+
+A healthy HPA reports current metric values and the `AbleToScale`,
+`ScalingActive`, and `ScalingLimited` conditions. A recommendation-only VPA
+populates `status.recommendation.containerRecommendations` after it has enough
+observations.
+
+## Troubleshoot autoscaling
+
+Use the following symptoms to locate the failing dependency:
+
+| Symptom | Check |
+| --- | --- |
+| HPA shows `<unknown>` for CPU or memory | Confirm Metrics Server health and resource requests on every relevant container. |
+| HPA reports a missing custom or external metric | Query the corresponding metrics API directly and check adapter discovery rules. |
+| Prometheus-backed metric is absent | Confirm the PrometheusRule was selected, the recording series exists, and the adapter exposes `hpa_metric: "true"` series. |
+| VPA has no recommendation | Confirm the recommender is running, the VPA target name is correct, and workload metrics are available. |
+| VPA does not update pods | Confirm the update mode, updater and admission-controller health, policy bounds, PDB, and cluster feature gates. |
+| Pods remain Pending after VPA updates | Compare recommendations and policy ceilings with node capacity, quotas, and LimitRanges. |
+
+## Roll back
+
+To stop horizontal scaling, set `autoscaling.horizontal.enabled: false` and set
+`replicaCount` to the required fixed capacity. Verify that the Deployment
+renders `spec.replicas` before applying the rollback.
+
+To stop VPA mutation while keeping recommendations, change `updateMode` to
+`"Off"`. To remove VPA entirely, set `autoscaling.vertical.enabled: false`.
+Disabling or deleting VPA does not restore resource requests on existing pods.
+Restore the intended Deployment resources in values and perform a controlled
+rollout. The restart replaces pods and can reduce capacity during rollout.
+Check the Deployment strategy, replica count, and PodDisruptionBudget before
+running it.
+
+```bash
+NAMESPACE=example
+DEPLOYMENT_NAME=example-universal-chart
+
+kubectl rollout restart deployment -n "${NAMESPACE}" "${DEPLOYMENT_NAME}"
+kubectl rollout status deployment -n "${NAMESPACE}" "${DEPLOYMENT_NAME}"
+```
+
+Set `DEPLOYMENT_NAME` to the rendered Deployment name when the release uses a
+name override.

--- a/charts/universal-chart/docs/index.md
+++ b/charts/universal-chart/docs/index.md
@@ -21,8 +21,9 @@ Kubernetes primitives plus a small number of opinionated platform integrations.
   `Database`, `DbUser`, or one-off Jobs
 - optional `ServiceMonitor`, with public nginx ingress access to the metrics
   path blocked by default
-- first-class HPA scaling from Prometheus-backed external metrics through
-  `autoscaling.hpaScalingRules`
+- stable `autoscaling/v2` HorizontalPodAutoscaler (HPA) support for resource,
+  container, object, pod, and external metrics
+- recommendation-only and active VerticalPodAutoscaler (VPA) support
 - optional `PodDisruptionBudget` through `podDisruptionBudget`
 - optional Redis support
 - optional S3 bucket creation via ACK-backed resources
@@ -88,34 +89,13 @@ When the chart is used from Argo multi-source applications:
 Treat it as the final deploy-time override so nothing later in the stack can
 silently replace image tags or release pins.
 
-## Scaling From Prometheus Metrics
+## Autoscaling
 
-Use `autoscaling.hpaScalingRules` when a workload should scale from an
-application metric exposed through Prometheus and `prometheus-adapter`. Each
-entry creates a Prometheus recording rule labeled `hpa_metric: "true"` and adds
-an External metric to the chart-managed `HorizontalPodAutoscaler`.
-
-```yaml
-prometheusRule:
-  additionalLabels:
-    release: kube-prometheus-stack
-
-autoscaling:
-  enabled: true
-  targetCPUUtilizationPercentage: null
-  hpaScalingRules:
-    - name: myapp_queue_depth
-      expr: |
-        sum(
-          myapp_queue_messages_ready{namespace="myapp"}
-        )
-      target:
-        type: AverageValue
-        averageValue: "100"
-```
-
-Keep CPU or memory targets enabled to combine them with the external metric, or
-set both target fields to `null` for external-only scaling.
+Use the [Autoscaling guide](autoscaling.md) to select and configure fixed
+replicas, HPA, VPA recommendation mode, active VPA, or a compatible HPA and VPA
+combination. The guide includes cluster prerequisites, copy-ready values,
+verification commands, troubleshooting, migration from legacy HPA values, and
+rollback procedures.
 
 ## PodDisruptionBudget
 

--- a/charts/universal-chart/mkdocs.yml
+++ b/charts/universal-chart/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: universal-chart
 docs_dir: docs
 nav:
   - Overview: index.md
+  - Autoscaling: autoscaling.md
   - Generated Reference: reference.md
 plugins:
   - techdocs-core

--- a/charts/universal-chart/templates/_autoscaling.tpl
+++ b/charts/universal-chart/templates/_autoscaling.tpl
@@ -1,0 +1,227 @@
+{{/*
+Build the canonical HorizontalPodAutoscaler configuration. New horizontal
+values override their legacy equivalents only when the new key is present.
+*/}}
+{{- define "universal-chart.autoscaling.horizontal" -}}
+{{- $legacy := .Values.autoscaling | default dict -}}
+{{- $horizontal := get $legacy "horizontal" | default dict -}}
+{{- $effective := dict -}}
+{{- range $key := list "enabled" "minReplicas" "maxReplicas" "annotations" "behavior" -}}
+  {{- $value := get $legacy $key -}}
+  {{- if hasKey $horizontal $key -}}
+    {{- $value = get $horizontal $key -}}
+  {{- end -}}
+  {{- $_ := set $effective $key (deepCopy $value) -}}
+{{- end -}}
+
+{{- $metrics := list -}}
+{{- if hasKey $horizontal "metrics" -}}
+  {{- $metrics = deepCopy (get $horizontal "metrics") -}}
+{{- else -}}
+  {{- with get $legacy "targetCPUUtilizationPercentage" -}}
+    {{- $metrics = append $metrics (dict
+      "type" "Resource"
+      "resource" (dict
+        "name" "cpu"
+        "target" (dict
+          "type" "Utilization"
+          "averageUtilization" .
+        )
+      )
+    ) -}}
+  {{- end -}}
+  {{- with get $legacy "targetMemoryUtilizationPercentage" -}}
+    {{- $metrics = append $metrics (dict
+      "type" "Resource"
+      "resource" (dict
+        "name" "memory"
+        "target" (dict
+          "type" "Utilization"
+          "averageUtilization" .
+        )
+      )
+    ) -}}
+  {{- end -}}
+{{- end -}}
+{{- $_ := set $effective "metrics" $metrics -}}
+{{- $_ := set $effective "metricsSource" (ternary "horizontal" "legacy" (hasKey $horizontal "metrics")) -}}
+
+{{- $prometheusScalingRules := get $legacy "hpaScalingRules" | default list -}}
+{{- if hasKey $horizontal "prometheusScalingRules" -}}
+  {{- $prometheusScalingRules = get $horizontal "prometheusScalingRules" | default list -}}
+{{- end -}}
+{{- $_ := set $effective "prometheusScalingRules" (deepCopy $prometheusScalingRules) -}}
+{{- toYaml $effective -}}
+{{- end }}
+
+{{/*
+Reject horizontal configurations that would render an inert or unsafe HPA.
+Schema validation owns structural checks; this helper owns cross-field checks.
+*/}}
+{{- define "universal-chart.autoscaling.validateHorizontal" -}}
+{{- $root := .root -}}
+{{- $config := .config -}}
+{{- if $config.enabled -}}
+  {{- $metricCount := add (len $config.metrics) (len $config.prometheusScalingRules) -}}
+  {{- if eq $metricCount 0 -}}
+    {{- fail "autoscaling.horizontal: enabled requires at least one metric or prometheusScalingRule" -}}
+  {{- end -}}
+  {{- if gt (int $config.minReplicas) (int $config.maxReplicas) -}}
+    {{- fail (printf "autoscaling.horizontal: minReplicas (%v) cannot exceed maxReplicas (%v)" $config.minReplicas $config.maxReplicas) -}}
+  {{- end -}}
+  {{/*
+  Missing requests make a utilization metric inert rather than invalid, so this
+  check only guards the new interface. Legacy releases that inherit
+  targetCPUUtilizationPercentage or targetMemoryUtilizationPercentage keep
+  rendering as they did before autoscaling.horizontal existed.
+  */}}
+  {{- if eq $config.metricsSource "horizontal" -}}
+    {{- $resources := include "universal-chart.containerResources" $root | fromYaml -}}
+    {{- $requests := get $resources "requests" | default dict -}}
+    {{- range $index, $metric := $config.metrics -}}
+      {{- if and (eq $metric.type "Resource") (eq $metric.resource.target.type "Utilization") -}}
+        {{- $resourceName := $metric.resource.name -}}
+        {{- if not (hasKey $requests $resourceName) -}}
+          {{- fail (printf "autoscaling.horizontal.metrics[%d]: Resource utilization for %s requires resources.requests.%s" $index $resourceName $resourceName) -}}
+        {{- end -}}
+      {{- else if and (eq $metric.type "ContainerResource") (eq $metric.containerResource.target.type "Utilization") (eq $metric.containerResource.container $root.Chart.Name) -}}
+        {{- $resourceName := $metric.containerResource.name -}}
+        {{- if not (hasKey $requests $resourceName) -}}
+          {{- fail (printf "autoscaling.horizontal.metrics[%d]: ContainerResource utilization for container %q and resource %s requires resources.requests.%s" $index $root.Chart.Name $resourceName $resourceName) -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Normalize a schema-validated Kubernetes quantity for VPA bound comparisons.
+*/}}
+{{- define "universal-chart.autoscaling.quantityFloat" -}}
+{{- $quantity := toString . -}}
+{{- $number := regexFind "^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)" $quantity -}}
+{{- $suffix := trimPrefix $number $quantity -}}
+{{- if regexMatch "^[eE][+-]?[0-9]+$" $suffix -}}
+  {{- float64 $quantity -}}
+{{- else -}}
+  {{- $multipliers := dict
+    "" "1"
+    "n" "1e-9"
+    "u" "1e-6"
+    "m" "1e-3"
+    "k" "1e3"
+    "K" "1e3"
+    "M" "1e6"
+    "G" "1e9"
+    "T" "1e12"
+    "P" "1e15"
+    "E" "1e18"
+    "Ki" "1024"
+    "Mi" "1048576"
+    "Gi" "1073741824"
+    "Ti" "1099511627776"
+    "Pi" "1125899906842624"
+    "Ei" "1152921504606846976"
+  -}}
+  {{- mulf (float64 $number) (float64 (get $multipliers $suffix)) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Reject vertical configurations without explicit mutation bounds and prevent
+request-based HPA/VPA feedback loops.
+*/}}
+{{- define "universal-chart.autoscaling.validateVertical" -}}
+{{- $root := .root -}}
+{{- $vertical := .vertical -}}
+{{- $updatePolicy := $vertical.updatePolicy | default dict -}}
+{{- $updateMode := $updatePolicy.updateMode | default "Off" -}}
+{{- $isActive := ne $updateMode "Off" -}}
+{{- $policies := $vertical.resourcePolicy.containerPolicies | default list -}}
+{{- if and $isActive (eq (len $policies) 0) -}}
+  {{- fail "autoscaling.vertical: active update modes require at least one containerPolicy with explicit resource ceilings" -}}
+{{- end -}}
+{{- $policyNames := dict -}}
+{{- range $index, $policy := $policies -}}
+  {{- if hasKey $policyNames $policy.containerName -}}
+    {{- fail (printf "autoscaling.vertical.resourcePolicy.containerPolicies[%d]: duplicate containerName %q" $index $policy.containerName) -}}
+  {{- end -}}
+  {{- $_ := set $policyNames $policy.containerName true -}}
+  {{- $policyMode := $policy.mode | default "Auto" -}}
+  {{- $minAllowed := $policy.minAllowed | default dict -}}
+  {{- $maxAllowed := $policy.maxAllowed | default dict -}}
+  {{- range $resourceName := list "cpu" "memory" -}}
+    {{- if and (hasKey $minAllowed $resourceName) (hasKey $maxAllowed $resourceName) -}}
+      {{- $minimum := include "universal-chart.autoscaling.quantityFloat" (get $minAllowed $resourceName) | float64 -}}
+      {{- $maximum := include "universal-chart.autoscaling.quantityFloat" (get $maxAllowed $resourceName) | float64 -}}
+      {{- if gt $minimum $maximum -}}
+        {{- fail (printf "autoscaling.vertical.resourcePolicy.containerPolicies[%d]: minAllowed.%s (%v) cannot exceed maxAllowed.%s (%v)" $index $resourceName (get $minAllowed $resourceName) $resourceName (get $maxAllowed $resourceName)) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if and $isActive (ne $policyMode "Off") -}}
+    {{- $controlledResources := $policy.controlledResources | default list -}}
+    {{- if eq (len $controlledResources) 0 -}}
+      {{- fail (printf "autoscaling.vertical.resourcePolicy.containerPolicies[%d]: active VPA policies require controlledResources" $index) -}}
+    {{- end -}}
+    {{- range $resourceName := $controlledResources -}}
+      {{- if not (hasKey $maxAllowed $resourceName) -}}
+        {{- fail (printf "autoscaling.vertical.resourcePolicy.containerPolicies[%d]: active VPA policy for %s requires maxAllowed.%s" $index $resourceName $resourceName) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if $isActive -}}
+  {{- $horizontal := include "universal-chart.autoscaling.horizontal" $root | fromYaml -}}
+  {{- if $horizontal.enabled -}}
+    {{- range $metricIndex, $metric := $horizontal.metrics -}}
+      {{- if and (eq $metric.type "Resource") (eq $metric.resource.target.type "Utilization") -}}
+        {{- range $policyIndex, $policy := $policies -}}
+          {{- $policyMode := $policy.mode | default "Auto" -}}
+          {{- if and (ne $policyMode "Off") (has $metric.resource.name ($policy.controlledResources | default list)) -}}
+            {{- fail (printf "autoscaling.vertical: active VPA policy %d controls %s, which conflicts with autoscaling.horizontal.metrics[%d] Resource utilization" $policyIndex $metric.resource.name $metricIndex) -}}
+          {{- end -}}
+        {{- end -}}
+      {{- else if and (eq $metric.type "ContainerResource") (eq $metric.containerResource.target.type "Utilization") -}}
+        {{- range $policyIndex, $policy := $policies -}}
+          {{- $policyMode := $policy.mode | default "Auto" -}}
+          {{- $containerMatches := or (eq $policy.containerName "*") (eq $policy.containerName $metric.containerResource.container) -}}
+          {{- if and (ne $policyMode "Off") $containerMatches (has $metric.containerResource.name ($policy.controlledResources | default list)) -}}
+            {{- fail (printf "autoscaling.vertical: active VPA policy %d controls %s for container %q, which conflicts with autoscaling.horizontal.metrics[%d] ContainerResource utilization" $policyIndex $metric.containerResource.name $metric.containerResource.container $metricIndex) -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render an External metric entry backed by a generated Prometheus recording rule.
+*/}}
+{{- define "universal-chart.autoscaling.prometheusMetric" -}}
+{{- $rule := .rule -}}
+{{- $index := .index -}}
+{{- $target := default dict $rule.target -}}
+{{- $targetType := default "AverageValue" $target.type -}}
+- type: External
+  external:
+    metric:
+      name: {{ required (printf "autoscaling prometheusScalingRules[%d].name is required" $index) $rule.name | quote }}
+      {{- with $rule.selector }}
+      selector:
+        matchLabels:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+    target:
+      type: {{ $targetType }}
+      {{- if eq $targetType "Value" }}
+      value: {{ required (printf "autoscaling prometheusScalingRules[%d].target.value is required when target.type is Value" $index) $target.value | quote }}
+      {{- else if eq $targetType "AverageValue" }}
+      averageValue: {{ required (printf "autoscaling prometheusScalingRules[%d].target.averageValue is required when target.type is AverageValue" $index) $target.averageValue | quote }}
+      {{- else }}
+      {{- fail (printf "autoscaling prometheusScalingRules[%d].target.type must be Value or AverageValue" $index) }}
+      {{- end }}
+{{- end }}

--- a/charts/universal-chart/templates/_helpers.tpl
+++ b/charts/universal-chart/templates/_helpers.tpl
@@ -77,79 +77,15 @@ values schema.
 {{- end }}
 
 {{/*
-Render an External metric entry for a HorizontalPodAutoscaler.
+Return the effective resource requirements for the primary container.
+extraContainerProps.resources historically rendered after resources, so an
+explicit value there takes precedence over the top-level resources value.
 */}}
-{{- define "universal-chart.hpa.externalMetric" -}}
-{{- $rule := .rule -}}
-{{- $index := .index -}}
-{{- $target := default dict $rule.target -}}
-{{- $targetType := default "AverageValue" $target.type -}}
-- type: External
-  external:
-    metric:
-      name: {{ required (printf "autoscaling.hpaScalingRules[%d].name is required" $index) $rule.name | quote }}
-      {{- with $rule.selector }}
-      selector:
-        matchLabels:
-          {{- toYaml . | nindent 10 }}
-      {{- end }}
-    target:
-      type: {{ $targetType }}
-      {{- if eq $targetType "Value" }}
-      value: {{ required (printf "autoscaling.hpaScalingRules[%d].target.value is required when target.type is Value" $index) $target.value | quote }}
-      {{- else if eq $targetType "AverageValue" }}
-      averageValue: {{ required (printf "autoscaling.hpaScalingRules[%d].target.averageValue is required when target.type is AverageValue" $index) $target.averageValue | quote }}
-      {{- else }}
-      {{- fail (printf "autoscaling.hpaScalingRules[%d].target.type must be Value or AverageValue" $index) }}
-      {{- end }}
-{{- end }}
-
-{{/*
-Render a HorizontalPodAutoscaler.
-*/}}
-{{- define "universal-chart.hpa" -}}
-{{- $root := .root -}}
-{{- $name := .name -}}
-{{- $rules := default list .rules -}}
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: {{ $name | quote }}
-  labels:
-    {{- include "universal-chart.labels" $root | nindent 4 }}
-  {{- with $root.Values.autoscaling.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: {{ include "universal-chart.fullname" $root }}
-  minReplicas: {{ $root.Values.autoscaling.minReplicas }}
-  maxReplicas: {{ $root.Values.autoscaling.maxReplicas }}
-  {{- with $root.Values.autoscaling.behavior }}
-  behavior:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  metrics:
-    {{- if $root.Values.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ $root.Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if $root.Values.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ $root.Values.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
-    {{- range $index, $rule := $rules }}
-    {{- include "universal-chart.hpa.externalMetric" (dict "rule" $rule "index" $index) | nindent 4 }}
-    {{- end }}
+{{- define "universal-chart.containerResources" -}}
+{{- $resources := deepCopy (.Values.resources | default dict) -}}
+{{- $extraContainerProps := .Values.extraContainerProps | default dict -}}
+{{- if hasKey $extraContainerProps "resources" -}}
+  {{- $resources = deepCopy (get $extraContainerProps "resources") -}}
+{{- end -}}
+{{- toYaml $resources -}}
 {{- end }}

--- a/charts/universal-chart/templates/deployment.yaml
+++ b/charts/universal-chart/templates/deployment.yaml
@@ -1,6 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
+{{- $horizontal := include "universal-chart.autoscaling.horizontal" . | fromYaml }}
 {{- $deploymentAnnotations := deepCopy (.Values.deployment.annotations | default dict) }}
+{{- $containerResources := include "universal-chart.containerResources" . | fromYaml }}
+{{- $extraContainerProps := deepCopy (.Values.extraContainerProps | default dict) }}
+{{- $_ := unset $extraContainerProps "resources" }}
 {{- $reloadAnnotation := "reloader.stakater.com/auto" }}
 {{- if and .Values.reloader.enabled (not (hasKey $deploymentAnnotations $reloadAnnotation)) }}
 {{- $_ := set $deploymentAnnotations $reloadAnnotation "true" }}
@@ -14,7 +18,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if not $horizontal.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
@@ -119,7 +123,7 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.resources }}
+          {{- with $containerResources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -127,7 +131,7 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.extraContainerProps }}
+          {{- with $extraContainerProps }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
 

--- a/charts/universal-chart/templates/hpa.yaml
+++ b/charts/universal-chart/templates/hpa.yaml
@@ -1,8 +1,32 @@
-{{- if .Values.autoscaling.enabled }}
-{{- $fullname := include "universal-chart.fullname" . }}
-{{- $hpaRules := default list .Values.autoscaling.hpaScalingRules }}
-{{- $hasHpa := or .Values.autoscaling.targetCPUUtilizationPercentage .Values.autoscaling.targetMemoryUtilizationPercentage (gt (len $hpaRules) 0) }}
-{{- if $hasHpa }}
-{{- include "universal-chart.hpa" (dict "root" . "name" $fullname "rules" $hpaRules) }}
-{{- end }}
+{{- $horizontal := include "universal-chart.autoscaling.horizontal" . | fromYaml -}}
+{{- include "universal-chart.autoscaling.validateHorizontal" (dict "root" . "config" $horizontal) -}}
+{{- if $horizontal.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "universal-chart.fullname" . | quote }}
+  labels:
+    {{- include "universal-chart.labels" . | nindent 4 }}
+  {{- with $horizontal.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "universal-chart.fullname" . }}
+  minReplicas: {{ $horizontal.minReplicas }}
+  maxReplicas: {{ $horizontal.maxReplicas }}
+  {{- with $horizontal.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  metrics:
+    {{- with $horizontal.metrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- range $index, $rule := $horizontal.prometheusScalingRules }}
+    {{- include "universal-chart.autoscaling.prometheusMetric" (dict "rule" $rule "index" $index) | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/universal-chart/templates/pdb.yaml
+++ b/charts/universal-chart/templates/pdb.yaml
@@ -5,9 +5,10 @@
 {{- if eq $hasMinAvailable $hasMaxUnavailable }}
 {{- fail "podDisruptionBudget: set exactly one of minAvailable or maxUnavailable" }}
 {{- end }}
+{{- $horizontal := include "universal-chart.autoscaling.horizontal" . | fromYaml }}
 {{- $replicas := .Values.replicaCount | int }}
-{{- if .Values.autoscaling.enabled }}
-{{- $replicas = .Values.autoscaling.minReplicas | int }}
+{{- if $horizontal.enabled }}
+{{- $replicas = $horizontal.minReplicas | int }}
 {{- end }}
 {{- if $hasMinAvailable }}
 {{- $minimumPods := $pdb.minAvailable | int }}

--- a/charts/universal-chart/templates/prometheusrule.yaml
+++ b/charts/universal-chart/templates/prometheusrule.yaml
@@ -1,5 +1,6 @@
-{{- $hpaScalingRules := default list .Values.autoscaling.hpaScalingRules }}
-{{- $hasHpaScalingRules := and .Values.autoscaling.enabled (gt (len $hpaScalingRules) 0) }}
+{{- $horizontal := include "universal-chart.autoscaling.horizontal" . | fromYaml }}
+{{- $hpaScalingRules := $horizontal.prometheusScalingRules }}
+{{- $hasHpaScalingRules := and $horizontal.enabled (gt (len $hpaScalingRules) 0) }}
 {{- $hasConfiguredRules := and .Values.prometheusRule.enabled (or .Values.prometheusRule.groups .Values.prometheusRule.rules) }}
 {{- if or $hasConfiguredRules $hasHpaScalingRules }}
 apiVersion: monitoring.coreos.com/v1
@@ -66,7 +67,7 @@ spec:
     {{- $scalingGroupOrder = append $scalingGroupOrder $groupKey }}
     {{- end }}
     {{- $labels := mergeOverwrite (deepCopy (default dict $rule.labels)) (dict "hpa_metric" "true") }}
-    {{- $recordingRule := dict "record" (required (printf "autoscaling.hpaScalingRules[%d].name is required" $index) $rule.name) "expr" (required (printf "autoscaling.hpaScalingRules[%d].expr is required" $index) $rule.expr) "labels" $labels }}
+    {{- $recordingRule := dict "record" (required (printf "autoscaling prometheusScalingRules[%d].name is required" $index) $rule.name) "expr" (required (printf "autoscaling prometheusScalingRules[%d].expr is required" $index) $rule.expr) "labels" $labels }}
     {{- $group := get $scalingGroups $groupKey }}
     {{- $_ := set $group "rules" (append (get $group "rules") $recordingRule) }}
     {{- end }}

--- a/charts/universal-chart/templates/vpa.yaml
+++ b/charts/universal-chart/templates/vpa.yaml
@@ -1,0 +1,28 @@
+{{- $vertical := .Values.autoscaling.vertical | default dict -}}
+{{- if $vertical.enabled -}}
+{{- include "universal-chart.autoscaling.validateVertical" (dict "root" . "vertical" $vertical) -}}
+{{- $updatePolicy := $vertical.updatePolicy | default dict -}}
+{{- $updateMode := $updatePolicy.updateMode | default "Off" -}}
+{{- $policies := $vertical.resourcePolicy.containerPolicies | default list -}}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "universal-chart.fullname" . | quote }}
+  labels:
+    {{- include "universal-chart.labels" . | nindent 4 }}
+  {{- with $vertical.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "universal-chart.fullname" . }}
+  updatePolicy:
+    updateMode: {{ $updateMode | quote }}
+    minReplicas: {{ $updatePolicy.minReplicas }}
+  resourcePolicy:
+    containerPolicies:
+      {{- toYaml $policies | nindent 6 }}
+{{- end }}

--- a/charts/universal-chart/values.schema.json
+++ b/charts/universal-chart/values.schema.json
@@ -1,6 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
+  "definitions": {
+    "quantity": {
+      "pattern": "^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+|[numkKMGTP]|[KMGTPE]i)?$",
+      "type": "string"
+    }
+  },
   "properties": {
     "affinity": {
       "additionalProperties": true,
@@ -11,20 +17,864 @@
     },
     "autoscaling": {
       "additionalProperties": false,
-      "description": "section for configuring autoscaling.\nMore information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/",
+      "description": "autoscaling configures horizontal and vertical pod autoscaling. Prefer\n`autoscaling.horizontal` for new HPA configurations. The legacy sibling HPA\nkeys remain supported; an explicitly supplied horizontal key overrides its\nlegacy equivalent.",
       "properties": {
         "annotations": {
-          "additionalProperties": true,
+          "additionalProperties": {
+            "type": "string"
+          },
           "required": [],
           "type": "object"
         },
         "behavior": {
-          "additionalProperties": true,
+          "additionalProperties": false,
+          "properties": {
+            "scaleDown": {
+              "additionalProperties": false,
+              "properties": {
+                "policies": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "periodSeconds": {
+                        "maximum": 1800,
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      "type": {
+                        "enum": [
+                          "Percent",
+                          "Pods"
+                        ],
+                        "type": "string"
+                      },
+                      "value": {
+                        "minimum": 1,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "value",
+                      "periodSeconds"
+                    ],
+                    "type": "object"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "selectPolicy": {
+                  "enum": [
+                    "Max",
+                    "Min",
+                    "Disabled"
+                  ],
+                  "type": "string"
+                },
+                "stabilizationWindowSeconds": {
+                  "maximum": 3600,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "tolerance": {
+                  "$ref": "#/definitions/quantity",
+                  "required": []
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "scaleUp": {
+              "additionalProperties": false,
+              "properties": {
+                "policies": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "periodSeconds": {
+                        "maximum": 1800,
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      "type": {
+                        "enum": [
+                          "Percent",
+                          "Pods"
+                        ],
+                        "type": "string"
+                      },
+                      "value": {
+                        "minimum": 1,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "value",
+                      "periodSeconds"
+                    ],
+                    "type": "object"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "selectPolicy": {
+                  "enum": [
+                    "Max",
+                    "Min",
+                    "Disabled"
+                  ],
+                  "type": "string"
+                },
+                "stabilizationWindowSeconds": {
+                  "maximum": 3600,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "tolerance": {
+                  "$ref": "#/definitions/quantity",
+                  "required": []
+                }
+              },
+              "required": [],
+              "type": "object"
+            }
+          },
           "required": [],
           "type": "object"
         },
         "enabled": {
           "type": "boolean"
+        },
+        "horizontal": {
+          "additionalProperties": false,
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "required": [],
+              "type": "object"
+            },
+            "behavior": {
+              "additionalProperties": false,
+              "properties": {
+                "scaleDown": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "policies": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "periodSeconds": {
+                            "maximum": 1800,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "type": {
+                            "enum": [
+                              "Percent",
+                              "Pods"
+                            ],
+                            "type": "string"
+                          },
+                          "value": {
+                            "minimum": 1,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "value",
+                          "periodSeconds"
+                        ],
+                        "type": "object"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "selectPolicy": {
+                      "enum": [
+                        "Max",
+                        "Min",
+                        "Disabled"
+                      ],
+                      "type": "string"
+                    },
+                    "stabilizationWindowSeconds": {
+                      "maximum": 3600,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "tolerance": {
+                      "$ref": "#/definitions/quantity",
+                      "required": []
+                    }
+                  },
+                  "required": [],
+                  "type": "object"
+                },
+                "scaleUp": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "policies": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "periodSeconds": {
+                            "maximum": 1800,
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "type": {
+                            "enum": [
+                              "Percent",
+                              "Pods"
+                            ],
+                            "type": "string"
+                          },
+                          "value": {
+                            "minimum": 1,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "value",
+                          "periodSeconds"
+                        ],
+                        "type": "object"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "selectPolicy": {
+                      "enum": [
+                        "Max",
+                        "Min",
+                        "Disabled"
+                      ],
+                      "type": "string"
+                    },
+                    "stabilizationWindowSeconds": {
+                      "maximum": 3600,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "tolerance": {
+                      "$ref": "#/definitions/quantity",
+                      "required": []
+                    }
+                  },
+                  "required": [],
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "maxReplicas": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "metrics": {
+              "items": {
+                "oneOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "resource": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "name": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "target": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "averageUtilization": {
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  },
+                                  "type": {
+                                    "const": "Utilization",
+                                    "required": []
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "averageUtilization"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "averageValue": {
+                                    "$ref": "#/definitions/quantity",
+                                    "required": []
+                                  },
+                                  "type": {
+                                    "const": "AverageValue",
+                                    "required": []
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "averageValue"
+                                ],
+                                "type": "object"
+                              }
+                            ],
+                            "required": []
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "target"
+                        ],
+                        "type": "object"
+                      },
+                      "type": {
+                        "const": "Resource",
+                        "required": []
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "resource"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "containerResource": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "container": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "name": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "target": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "averageUtilization": {
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  },
+                                  "type": {
+                                    "const": "Utilization",
+                                    "required": []
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "averageUtilization"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "averageValue": {
+                                    "$ref": "#/definitions/quantity",
+                                    "required": []
+                                  },
+                                  "type": {
+                                    "const": "AverageValue",
+                                    "required": []
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "averageValue"
+                                ],
+                                "type": "object"
+                              }
+                            ],
+                            "required": []
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "container",
+                          "target"
+                        ],
+                        "type": "object"
+                      },
+                      "type": {
+                        "const": "ContainerResource",
+                        "required": []
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "containerResource"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "external": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "metric": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "name": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "selector": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "key": {
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "enum": [
+                                            "In",
+                                            "NotIn",
+                                            "Exists",
+                                            "DoesNotExist"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "required": [],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "target": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "type": {
+                                    "const": "Value",
+                                    "required": []
+                                  },
+                                  "value": {
+                                    "$ref": "#/definitions/quantity",
+                                    "required": []
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "value"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "averageValue": {
+                                    "$ref": "#/definitions/quantity",
+                                    "required": []
+                                  },
+                                  "type": {
+                                    "const": "AverageValue",
+                                    "required": []
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "averageValue"
+                                ],
+                                "type": "object"
+                              }
+                            ],
+                            "required": []
+                          }
+                        },
+                        "required": [
+                          "metric",
+                          "target"
+                        ],
+                        "type": "object"
+                      },
+                      "type": {
+                        "const": "External",
+                        "required": []
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "external"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "object": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "describedObject": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "apiVersion": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "kind": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "name": {
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "apiVersion",
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "metric": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "name": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "selector": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "key": {
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "enum": [
+                                            "In",
+                                            "NotIn",
+                                            "Exists",
+                                            "DoesNotExist"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "required": [],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "target": {
+                            "oneOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "type": {
+                                    "const": "Value",
+                                    "required": []
+                                  },
+                                  "value": {
+                                    "$ref": "#/definitions/quantity",
+                                    "required": []
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "value"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "averageValue": {
+                                    "$ref": "#/definitions/quantity",
+                                    "required": []
+                                  },
+                                  "type": {
+                                    "const": "AverageValue",
+                                    "required": []
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "averageValue"
+                                ],
+                                "type": "object"
+                              }
+                            ],
+                            "required": []
+                          }
+                        },
+                        "required": [
+                          "describedObject",
+                          "metric",
+                          "target"
+                        ],
+                        "type": "object"
+                      },
+                      "type": {
+                        "const": "Object",
+                        "required": []
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "object"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "pods": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "metric": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "name": {
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "selector": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "key": {
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "enum": [
+                                            "In",
+                                            "NotIn",
+                                            "Exists",
+                                            "DoesNotExist"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "required": [],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [],
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "target": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "averageValue": {
+                                "$ref": "#/definitions/quantity",
+                                "required": []
+                              },
+                              "type": {
+                                "const": "AverageValue",
+                                "required": []
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "averageValue"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "metric",
+                          "target"
+                        ],
+                        "type": "object"
+                      },
+                      "type": {
+                        "const": "Pods",
+                        "required": []
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "pods"
+                    ],
+                    "type": "object"
+                  }
+                ],
+                "required": []
+              },
+              "type": "array"
+            },
+            "minReplicas": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "prometheusScalingRules": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "expr": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "groupName": {
+                    "type": "string"
+                  },
+                  "interval": {
+                    "type": "string"
+                  },
+                  "labels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "name": {
+                    "pattern": "^[a-zA-Z_:][a-zA-Z0-9_:]*$",
+                    "type": "string"
+                  },
+                  "selector": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "target": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "averageValue": {
+                        "$ref": "#/definitions/quantity",
+                        "required": []
+                      },
+                      "type": {
+                        "enum": [
+                          "Value",
+                          "AverageValue"
+                        ],
+                        "type": "string"
+                      },
+                      "value": {
+                        "$ref": "#/definitions/quantity",
+                        "required": []
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "name",
+                  "expr",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [],
+          "type": "object"
         },
         "hpaScalingRules": {
           "items": {
@@ -61,7 +911,8 @@
                 "additionalProperties": false,
                 "properties": {
                   "averageValue": {
-                    "type": "string"
+                    "$ref": "#/definitions/quantity",
+                    "required": []
                   },
                   "type": {
                     "enum": [
@@ -71,7 +922,8 @@
                     "type": "string"
                   },
                   "value": {
-                    "type": "string"
+                    "$ref": "#/definitions/quantity",
+                    "required": []
                   }
                 },
                 "required": [],
@@ -98,6 +950,7 @@
         "targetCPUUtilizationPercentage": {
           "anyOf": [
             {
+              "maximum": 100,
               "minimum": 1,
               "type": "integer"
             },
@@ -110,6 +963,7 @@
         "targetMemoryUtilizationPercentage": {
           "anyOf": [
             {
+              "maximum": 100,
               "minimum": 1,
               "type": "integer"
             },
@@ -118,6 +972,128 @@
             }
           ],
           "required": []
+        },
+        "vertical": {
+          "additionalProperties": false,
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "required": [],
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "resourcePolicy": {
+              "additionalProperties": false,
+              "properties": {
+                "containerPolicies": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "containerName": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "controlledResources": {
+                        "items": {
+                          "enum": [
+                            "cpu",
+                            "memory"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": true
+                      },
+                      "controlledValues": {
+                        "enum": [
+                          "RequestsOnly",
+                          "RequestsAndLimits"
+                        ],
+                        "type": "string"
+                      },
+                      "maxAllowed": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "cpu": {
+                            "$ref": "#/definitions/quantity",
+                            "required": []
+                          },
+                          "memory": {
+                            "$ref": "#/definitions/quantity",
+                            "required": []
+                          }
+                        },
+                        "required": [],
+                        "type": "object"
+                      },
+                      "minAllowed": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "cpu": {
+                            "$ref": "#/definitions/quantity",
+                            "required": []
+                          },
+                          "memory": {
+                            "$ref": "#/definitions/quantity",
+                            "required": []
+                          }
+                        },
+                        "required": [],
+                        "type": "object"
+                      },
+                      "mode": {
+                        "enum": [
+                          "Auto",
+                          "Off"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "containerName",
+                      "controlledResources",
+                      "controlledValues"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "containerPolicies"
+              ],
+              "type": "object"
+            },
+            "updatePolicy": {
+              "additionalProperties": false,
+              "properties": {
+                "minReplicas": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "updateMode": {
+                  "enum": [
+                    "Off",
+                    "Initial",
+                    "Recreate",
+                    "InPlaceOrRecreate"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "updateMode",
+                "minReplicas"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [],
+          "type": "object"
         }
       },
       "required": [],

--- a/charts/universal-chart/values.yaml
+++ b/charts/universal-chart/values.yaml
@@ -340,6 +340,10 @@ service:
 
 # @schema
 # type: object
+# definitions:
+#   quantity:
+#     type: string
+#     pattern: ^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+|[numkKMGTP]|[KMGTPE]i)?$
 # properties:
 #   enabled:
 #     type: boolean
@@ -766,18 +770,84 @@ revisionHistoryLimit: 3
 #     anyOf:
 #       - type: integer
 #         minimum: 1
+#         maximum: 100
 #       - type: "null"
 #   targetMemoryUtilizationPercentage:
 #     anyOf:
 #       - type: integer
 #         minimum: 1
+#         maximum: 100
 #       - type: "null"
 #   annotations:
 #     type: object
-#     additionalProperties: true
+#     additionalProperties:
+#       type: string
 #   behavior:
 #     type: object
-#     additionalProperties: true
+#     properties:
+#       scaleUp:
+#         type: object
+#         properties:
+#           stabilizationWindowSeconds:
+#             type: integer
+#             minimum: 0
+#             maximum: 3600
+#           selectPolicy:
+#             type: string
+#             enum: [Max, Min, Disabled]
+#           tolerance:
+#             $ref: "#/definitions/quantity"
+#           policies:
+#             type: array
+#             minItems: 1
+#             items:
+#               type: object
+#               required: [type, value, periodSeconds]
+#               properties:
+#                 type:
+#                   type: string
+#                   enum: [Percent, Pods]
+#                 value:
+#                   type: integer
+#                   minimum: 1
+#                 periodSeconds:
+#                   type: integer
+#                   minimum: 1
+#                   maximum: 1800
+#               additionalProperties: false
+#         additionalProperties: false
+#       scaleDown:
+#         type: object
+#         properties:
+#           stabilizationWindowSeconds:
+#             type: integer
+#             minimum: 0
+#             maximum: 3600
+#           selectPolicy:
+#             type: string
+#             enum: [Max, Min, Disabled]
+#           tolerance:
+#             $ref: "#/definitions/quantity"
+#           policies:
+#             type: array
+#             minItems: 1
+#             items:
+#               type: object
+#               required: [type, value, periodSeconds]
+#               properties:
+#                 type:
+#                   type: string
+#                   enum: [Percent, Pods]
+#                 value:
+#                   type: integer
+#                   minimum: 1
+#                 periodSeconds:
+#                   type: integer
+#                   minimum: 1
+#                   maximum: 1800
+#               additionalProperties: false
+#         additionalProperties: false
+#     additionalProperties: false
 #   hpaScalingRules:
 #     type: array
 #     items:
@@ -809,37 +879,488 @@ revisionHistoryLimit: 3
 #                 - Value
 #                 - AverageValue
 #             value:
-#               type: string
+#               $ref: "#/definitions/quantity"
 #             averageValue:
-#               type: string
+#               $ref: "#/definitions/quantity"
 #           additionalProperties: false
 #         groupName:
 #           type: string
 #         interval:
 #           type: string
 #       additionalProperties: false
+#   horizontal:
+#     type: object
+#     properties:
+#       enabled:
+#         type: boolean
+#       minReplicas:
+#         type: integer
+#         minimum: 1
+#       maxReplicas:
+#         type: integer
+#         minimum: 1
+#       annotations:
+#         type: object
+#         additionalProperties:
+#           type: string
+#       behavior:
+#         type: object
+#         properties:
+#           scaleUp:
+#             type: object
+#             properties:
+#               stabilizationWindowSeconds:
+#                 type: integer
+#                 minimum: 0
+#                 maximum: 3600
+#               selectPolicy:
+#                 type: string
+#                 enum: [Max, Min, Disabled]
+#               tolerance:
+#                 $ref: "#/definitions/quantity"
+#               policies:
+#                 type: array
+#                 minItems: 1
+#                 items:
+#                   type: object
+#                   required: [type, value, periodSeconds]
+#                   properties:
+#                     type:
+#                       type: string
+#                       enum: [Percent, Pods]
+#                     value:
+#                       type: integer
+#                       minimum: 1
+#                     periodSeconds:
+#                       type: integer
+#                       minimum: 1
+#                       maximum: 1800
+#                   additionalProperties: false
+#             additionalProperties: false
+#           scaleDown:
+#             type: object
+#             properties:
+#               stabilizationWindowSeconds:
+#                 type: integer
+#                 minimum: 0
+#                 maximum: 3600
+#               selectPolicy:
+#                 type: string
+#                 enum: [Max, Min, Disabled]
+#               tolerance:
+#                 $ref: "#/definitions/quantity"
+#               policies:
+#                 type: array
+#                 minItems: 1
+#                 items:
+#                   type: object
+#                   required: [type, value, periodSeconds]
+#                   properties:
+#                     type:
+#                       type: string
+#                       enum: [Percent, Pods]
+#                     value:
+#                       type: integer
+#                       minimum: 1
+#                     periodSeconds:
+#                       type: integer
+#                       minimum: 1
+#                       maximum: 1800
+#                   additionalProperties: false
+#             additionalProperties: false
+#         additionalProperties: false
+#       metrics:
+#         type: array
+#         items:
+#           oneOf:
+#             - type: object
+#               required: [type, resource]
+#               properties:
+#                 type:
+#                   const: Resource
+#                 resource:
+#                   type: object
+#                   required: [name, target]
+#                   properties:
+#                     name:
+#                       type: string
+#                       minLength: 1
+#                     target:
+#                       oneOf:
+#                         - type: object
+#                           required: [type, averageUtilization]
+#                           properties:
+#                             type:
+#                               const: Utilization
+#                             averageUtilization:
+#                               type: integer
+#                               minimum: 1
+#                           additionalProperties: false
+#                         - type: object
+#                           required: [type, averageValue]
+#                           properties:
+#                             type:
+#                               const: AverageValue
+#                             averageValue:
+#                               $ref: "#/definitions/quantity"
+#                           additionalProperties: false
+#                   additionalProperties: false
+#               additionalProperties: false
+#             - type: object
+#               required: [type, containerResource]
+#               properties:
+#                 type:
+#                   const: ContainerResource
+#                 containerResource:
+#                   type: object
+#                   required: [name, container, target]
+#                   properties:
+#                     name:
+#                       type: string
+#                       minLength: 1
+#                     container:
+#                       type: string
+#                       minLength: 1
+#                     target:
+#                       oneOf:
+#                         - type: object
+#                           required: [type, averageUtilization]
+#                           properties:
+#                             type:
+#                               const: Utilization
+#                             averageUtilization:
+#                               type: integer
+#                               minimum: 1
+#                           additionalProperties: false
+#                         - type: object
+#                           required: [type, averageValue]
+#                           properties:
+#                             type:
+#                               const: AverageValue
+#                             averageValue:
+#                               $ref: "#/definitions/quantity"
+#                           additionalProperties: false
+#                   additionalProperties: false
+#               additionalProperties: false
+#             - type: object
+#               required: [type, external]
+#               properties:
+#                 type:
+#                   const: External
+#                 external:
+#                   type: object
+#                   required: [metric, target]
+#                   properties:
+#                     metric:
+#                       type: object
+#                       required: [name]
+#                       properties:
+#                         name:
+#                           type: string
+#                           minLength: 1
+#                         selector:
+#                           type: object
+#                           properties:
+#                             matchLabels:
+#                               type: object
+#                               additionalProperties:
+#                                 type: string
+#                             matchExpressions:
+#                               type: array
+#                               items:
+#                                 type: object
+#                                 required: [key, operator]
+#                                 properties:
+#                                   key:
+#                                     type: string
+#                                     minLength: 1
+#                                   operator:
+#                                     type: string
+#                                     enum: [In, NotIn, Exists, DoesNotExist]
+#                                   values:
+#                                     type: array
+#                                     items:
+#                                       type: string
+#                                 additionalProperties: false
+#                           additionalProperties: false
+#                       additionalProperties: false
+#                     target:
+#                       oneOf:
+#                         - type: object
+#                           required: [type, value]
+#                           properties:
+#                             type:
+#                               const: Value
+#                             value:
+#                               $ref: "#/definitions/quantity"
+#                           additionalProperties: false
+#                         - type: object
+#                           required: [type, averageValue]
+#                           properties:
+#                             type:
+#                               const: AverageValue
+#                             averageValue:
+#                               $ref: "#/definitions/quantity"
+#                           additionalProperties: false
+#                   additionalProperties: false
+#               additionalProperties: false
+#             - type: object
+#               required: [type, object]
+#               properties:
+#                 type:
+#                   const: Object
+#                 object:
+#                   type: object
+#                   required: [describedObject, metric, target]
+#                   properties:
+#                     describedObject:
+#                       type: object
+#                       required: [apiVersion, kind, name]
+#                       properties:
+#                         apiVersion:
+#                           type: string
+#                           minLength: 1
+#                         kind:
+#                           type: string
+#                           minLength: 1
+#                         name:
+#                           type: string
+#                           minLength: 1
+#                       additionalProperties: false
+#                     metric:
+#                       type: object
+#                       required: [name]
+#                       properties:
+#                         name:
+#                           type: string
+#                           minLength: 1
+#                         selector:
+#                           type: object
+#                           properties:
+#                             matchLabels:
+#                               type: object
+#                               additionalProperties:
+#                                 type: string
+#                             matchExpressions:
+#                               type: array
+#                               items:
+#                                 type: object
+#                                 required: [key, operator]
+#                                 properties:
+#                                   key:
+#                                     type: string
+#                                     minLength: 1
+#                                   operator:
+#                                     type: string
+#                                     enum: [In, NotIn, Exists, DoesNotExist]
+#                                   values:
+#                                     type: array
+#                                     items:
+#                                       type: string
+#                                 additionalProperties: false
+#                           additionalProperties: false
+#                       additionalProperties: false
+#                     target:
+#                       oneOf:
+#                         - type: object
+#                           required: [type, value]
+#                           properties:
+#                             type:
+#                               const: Value
+#                             value:
+#                               $ref: "#/definitions/quantity"
+#                           additionalProperties: false
+#                         - type: object
+#                           required: [type, averageValue]
+#                           properties:
+#                             type:
+#                               const: AverageValue
+#                             averageValue:
+#                               $ref: "#/definitions/quantity"
+#                           additionalProperties: false
+#                   additionalProperties: false
+#               additionalProperties: false
+#             - type: object
+#               required: [type, pods]
+#               properties:
+#                 type:
+#                   const: Pods
+#                 pods:
+#                   type: object
+#                   required: [metric, target]
+#                   properties:
+#                     metric:
+#                       type: object
+#                       required: [name]
+#                       properties:
+#                         name:
+#                           type: string
+#                           minLength: 1
+#                         selector:
+#                           type: object
+#                           properties:
+#                             matchLabels:
+#                               type: object
+#                               additionalProperties:
+#                                 type: string
+#                             matchExpressions:
+#                               type: array
+#                               items:
+#                                 type: object
+#                                 required: [key, operator]
+#                                 properties:
+#                                   key:
+#                                     type: string
+#                                     minLength: 1
+#                                   operator:
+#                                     type: string
+#                                     enum: [In, NotIn, Exists, DoesNotExist]
+#                                   values:
+#                                     type: array
+#                                     items:
+#                                       type: string
+#                                 additionalProperties: false
+#                           additionalProperties: false
+#                       additionalProperties: false
+#                     target:
+#                       type: object
+#                       required: [type, averageValue]
+#                       properties:
+#                         type:
+#                           const: AverageValue
+#                         averageValue:
+#                           $ref: "#/definitions/quantity"
+#                       additionalProperties: false
+#                   additionalProperties: false
+#               additionalProperties: false
+#       prometheusScalingRules:
+#         type: array
+#         items:
+#           type: object
+#           required: [name, expr, target]
+#           properties:
+#             name:
+#               type: string
+#               pattern: ^[a-zA-Z_:][a-zA-Z0-9_:]*$
+#             expr:
+#               type: string
+#               minLength: 1
+#             labels:
+#               type: object
+#               additionalProperties:
+#                 type: string
+#             selector:
+#               type: object
+#               additionalProperties:
+#                 type: string
+#             target:
+#               type: object
+#               properties:
+#                 type:
+#                   type: string
+#                   enum: [Value, AverageValue]
+#                 value:
+#                   $ref: "#/definitions/quantity"
+#                 averageValue:
+#                   $ref: "#/definitions/quantity"
+#               additionalProperties: false
+#             groupName:
+#               type: string
+#             interval:
+#               type: string
+#           additionalProperties: false
+#     additionalProperties: false
+#   vertical:
+#     type: object
+#     properties:
+#       enabled:
+#         type: boolean
+#       annotations:
+#         type: object
+#         additionalProperties:
+#           type: string
+#       updatePolicy:
+#         type: object
+#         required: [updateMode, minReplicas]
+#         properties:
+#           updateMode:
+#             type: string
+#             enum: [Off, Initial, Recreate, InPlaceOrRecreate]
+#           minReplicas:
+#             type: integer
+#             minimum: 1
+#         additionalProperties: false
+#       resourcePolicy:
+#         type: object
+#         required: [containerPolicies]
+#         properties:
+#           containerPolicies:
+#             type: array
+#             items:
+#               type: object
+#               required: [containerName, controlledResources, controlledValues]
+#               properties:
+#                 containerName:
+#                   type: string
+#                   minLength: 1
+#                 mode:
+#                   type: string
+#                   enum: [Auto, "Off"]
+#                 minAllowed:
+#                   type: object
+#                   properties:
+#                     cpu:
+#                       $ref: "#/definitions/quantity"
+#                     memory:
+#                       $ref: "#/definitions/quantity"
+#                   additionalProperties: false
+#                 maxAllowed:
+#                   type: object
+#                   properties:
+#                     cpu:
+#                       $ref: "#/definitions/quantity"
+#                     memory:
+#                       $ref: "#/definitions/quantity"
+#                   additionalProperties: false
+#                 controlledResources:
+#                   type: array
+#                   uniqueItems: true
+#                   items:
+#                     type: string
+#                     enum: [cpu, memory]
+#                 controlledValues:
+#                   type: string
+#                   enum: [RequestsOnly, RequestsAndLimits]
+#               additionalProperties: false
+#         additionalProperties: false
+#     additionalProperties: false
+# additionalProperties: false
 # @schema
-# -- section for configuring autoscaling.
-# More information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+# -- autoscaling configures horizontal and vertical pod autoscaling. Prefer
+# `autoscaling.horizontal` for new HPA configurations. The legacy sibling HPA
+# keys remain supported; an explicitly supplied horizontal key overrides its
+# legacy equivalent.
 autoscaling:
-  # -- enable autoscaling
+  # -- enabled is the legacy HPA switch. Prefer `horizontal.enabled`.
   enabled: false
-  # -- miminum number of replicas to run
+  # -- minReplicas is the legacy HPA floor. Prefer `horizontal.minReplicas`.
   minReplicas: 1
-  # -- maximum number of replicas to run
+  # -- maxReplicas is the legacy HPA ceiling. Prefer `horizontal.maxReplicas`.
   maxReplicas: 10
-  # -- If CPU utilization of replicas exceeds this percentage of requested CPU, start a new replica
+  # -- targetCPUUtilizationPercentage is the legacy CPU utilization target.
+  # It requires `resources.requests.cpu`.
   targetCPUUtilizationPercentage: 80
-  # -- If Memory utilization of replicas exceeds this percentage of requested Memory, start a new replica
+  # -- targetMemoryUtilizationPercentage is the legacy memory utilization
+  # target. It requires `resources.requests.memory`.
   targetMemoryUtilizationPercentage: null
-  # -- Additional annotations to add to the HorizontalPodAutoscaler metadata.
+  # -- annotations are the legacy HPA annotations. Prefer
+  # `horizontal.annotations`.
   annotations: {}
-  # -- Optional HorizontalPodAutoscaler behavior defaults.
+  # -- behavior is the legacy autoscaling/v2 HPA behavior. Prefer
+  # `horizontal.behavior`.
   behavior: {}
-  # -- Prometheus-backed external metric scaling rules. Each rule generates a
-  # Prometheus recording rule labeled `hpa_metric: "true"` and adds an External
-  # metric to the chart-managed HPA. Set `targetCPUUtilizationPercentage: null`
-  # and `targetMemoryUtilizationPercentage: null` for external-only scaling.
+  # -- hpaScalingRules are the legacy Prometheus-backed scaling rules. Prefer
+  # `horizontal.prometheusScalingRules`.
   hpaScalingRules: []
   # - name: myapp_queue_depth
   #   expr: |
@@ -849,6 +1370,58 @@ autoscaling:
   #   target:
   #     type: AverageValue
   #     averageValue: "100"
+  # -- horizontal is the stable autoscaling/v2 HorizontalPodAutoscaler
+  # configuration. Explicit keys override legacy sibling keys; omitted keys
+  # inherit them.
+  horizontal: {}
+  # enabled: true
+  # minReplicas: 2
+  # maxReplicas: 10
+  # annotations: {}
+  # behavior: {}
+  # metrics:
+  #   - type: Resource
+  #     resource:
+  #       name: cpu
+  #       target:
+  #         type: Utilization
+  #         averageUtilization: 80
+  # prometheusScalingRules: []
+  # -- vertical configures VerticalPodAutoscaler. Enabling update mode `Off`
+  # creates recommendations without mutating pods. Active modes require a
+  # `maxAllowed` ceiling for every controlled resource.
+  vertical:
+    # -- enabled creates an autoscaling.k8s.io/v1 VerticalPodAutoscaler.
+    enabled: false
+    # -- annotations are added to VerticalPodAutoscaler metadata.
+    annotations: {}
+    # -- updatePolicy controls VPA mutation. `InPlaceOrRecreate` requires
+    # compatible cluster and VPA feature gates and may fall back to eviction.
+    updatePolicy:
+      # -- updateMode selects recommendation-only or active VPA behavior.
+      updateMode: "Off"
+      # -- minReplicas prevents active VPA from reducing available pods below
+      # this count during updates.
+      minReplicas: 2
+    # -- resourcePolicy defines per-container recommendation and mutation
+    # boundaries.
+    resourcePolicy:
+      # -- containerPolicies select controlled containers and resource bounds.
+      containerPolicies:
+        # -- containerName selects all containers by default.
+        - containerName: "*"
+          # -- mode enables recommendations for the selected containers.
+          mode: Auto
+          # -- controlledResources limits VPA to CPU and memory requests.
+          controlledResources:
+            - cpu
+            - memory
+          # -- controlledValues changes requests without changing limits.
+          controlledValues: RequestsOnly
+          # -- minAllowed optionally sets resource recommendation floors.
+          minAllowed: {}
+          # -- maxAllowed sets required ceilings before activating VPA.
+          maxAllowed: {}
 
 # -- Additional volumes to create
 volumes: []

--- a/tests/fixtures/universal-chart/hpa-v2-values.golden.yaml
+++ b/tests/fixtures/universal-chart/hpa-v2-values.golden.yaml
@@ -91,19 +91,24 @@ metadata:
     app.kubernetes.io/name: universal-chart
     app.kubernetes.io/instance: universal-chart
     app.kubernetes.io/managed-by: Helm
-  annotations:
-    argocd.argoproj.io/sync-wave: "10"
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: universal-chart
   minReplicas: 2
-  maxReplicas: 4
+  maxReplicas: 12
   metrics:
     - resource:
         name: cpu
         target:
-          averageUtilization: 75
+          averageUtilization: 70
           type: Utilization
       type: Resource
+    - external:
+        metric:
+          name: queue_depth
+        target:
+          averageValue: "20"
+          type: AverageValue
+      type: External

--- a/tests/fixtures/universal-chart/hpa-v2-values.yaml
+++ b/tests/fixtures/universal-chart/hpa-v2-values.yaml
@@ -1,0 +1,27 @@
+image:
+  repository: ghcr.io/example/app
+  tag: "1.2.3"
+
+autoscaling:
+  horizontal:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 12
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 70
+      - type: External
+        external:
+          metric:
+            name: queue_depth
+          target:
+            type: AverageValue
+            averageValue: "20"
+
+resources:
+  requests:
+    cpu: 100m

--- a/tests/fixtures/universal-chart/hpa-values.yaml
+++ b/tests/fixtures/universal-chart/hpa-values.yaml
@@ -9,3 +9,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 75
   annotations:
     argocd.argoproj.io/sync-wave: "10"
+
+resources:
+  requests:
+    cpu: 100m

--- a/tests/fixtures/universal-chart/vpa-values.golden.yaml
+++ b/tests/fixtures/universal-chart/vpa-values.golden.yaml
@@ -43,6 +43,7 @@ metadata:
     app.kubernetes.io/instance: universal-chart
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
@@ -69,9 +70,6 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
-          resources:
-            requests:
-              cpu: 100m
       topologySpreadConstraints:
         - labelSelector:
             matchLabels:
@@ -81,9 +79,9 @@ spec:
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: ScheduleAnyway
 ---
-# Source: universal-chart/templates/hpa.yaml
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
+# Source: universal-chart/templates/vpa.yaml
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
 metadata:
   name: "universal-chart"
   labels:
@@ -94,16 +92,22 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "10"
 spec:
-  scaleTargetRef:
+  targetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: universal-chart
-  minReplicas: 2
-  maxReplicas: 4
-  metrics:
-    - resource:
-        name: cpu
-        target:
-          averageUtilization: 75
-          type: Utilization
-      type: Resource
+  updatePolicy:
+    updateMode: "Off"
+    minReplicas: 2
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        controlledResources:
+        - cpu
+        - memory
+        controlledValues: RequestsOnly
+        maxAllowed: {}
+        minAllowed:
+          cpu: 50m
+          memory: 64Mi
+        mode: Auto

--- a/tests/fixtures/universal-chart/vpa-values.yaml
+++ b/tests/fixtures/universal-chart/vpa-values.yaml
@@ -1,0 +1,24 @@
+image:
+  repository: ghcr.io/example/app
+  tag: "1.2.3"
+
+autoscaling:
+  vertical:
+    enabled: true
+    annotations:
+      argocd.argoproj.io/sync-wave: "10"
+    updatePolicy:
+      updateMode: "Off"
+      minReplicas: 2
+    resourcePolicy:
+      containerPolicies:
+        - containerName: "*"
+          mode: Auto
+          controlledResources:
+            - cpu
+            - memory
+          controlledValues: RequestsOnly
+          minAllowed:
+            cpu: 50m
+            memory: 64Mi
+          maxAllowed: {}

--- a/tests/test_universal_chart_autoscaling_docs.py
+++ b/tests/test_universal_chart_autoscaling_docs.py
@@ -1,0 +1,34 @@
+"""Validation for universal-chart autoscaling documentation examples."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from .chart_test_utils import REPO_ROOT
+
+DOCS = REPO_ROOT / "charts" / "universal-chart" / "docs" / "autoscaling.md"
+README_TEMPLATE = REPO_ROOT / "charts" / "universal-chart" / "README.md.gotmpl"
+
+
+def _yaml_blocks(path: Path) -> list[str]:
+    """Return every fenced YAML example in a Markdown document."""
+
+    return re.findall(r"```yaml\n(.*?)\n```", path.read_text(), re.DOTALL)
+
+
+def test_autoscaling_yaml_examples_parse() -> None:
+    """Keep every copyable autoscaling values example syntactically valid."""
+
+    for path in (DOCS, README_TEMPLATE):
+        blocks = [
+            block for block in _yaml_blocks(path) if "autoscaling:" in block
+        ]
+        assert blocks, f"expected YAML examples in {path}"
+        for block in blocks:
+            parsed = yaml.safe_load(block)
+            assert isinstance(
+                parsed, dict
+            ), f"expected values mapping in {path}"

--- a/tests/test_universal_chart_core.py
+++ b/tests/test_universal_chart_core.py
@@ -6,7 +6,12 @@ from typing import Any
 
 import pytest
 
-from .chart_test_utils import get_manifest, get_primary_container, render_chart
+from .chart_test_utils import (
+    get_manifest,
+    get_primary_container,
+    load_manifests,
+    render_chart,
+)
 from .universal_chart_test_utils import CHART, render_manifests
 
 
@@ -96,6 +101,40 @@ def test_resources_render_requested_limits(
     )
 
     assert container["resources"] == expected
+
+
+def test_extra_container_props_can_supply_resources(helm_runner) -> None:
+    """Treat legacy extra container resources as the effective requirements."""
+
+    expected = {"requests": {"cpu": "100m", "memory": "128Mi"}}
+    container = get_primary_container(
+        render_manifests(
+            helm_runner,
+            values={"extraContainerProps": {"resources": expected}},
+        )
+    )
+
+    assert container["resources"] == expected
+
+
+def test_extra_container_props_resources_override_top_level_resources(
+    helm_runner,
+) -> None:
+    """Preserve the historical precedence without duplicate YAML keys."""
+
+    expected = {"requests": {"memory": "128Mi"}}
+    rendered = render_chart(
+        helm_runner,
+        CHART,
+        values={
+            "resources": {"requests": {"cpu": "250m"}},
+            "extraContainerProps": {"resources": expected},
+        },
+    )
+    container = get_primary_container(load_manifests(rendered))
+
+    assert container["resources"] == expected
+    assert rendered.count("\n          resources:") == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_universal_chart_hpa.py
+++ b/tests/test_universal_chart_hpa.py
@@ -2,14 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
-
-import pytest
-
-from .chart_test_utils import get_manifest, render_chart
-from .conftest import HelmTemplateError
+from .chart_test_utils import get_manifest
 from .universal_chart_test_utils import (
-    CHART,
     render_manifest,
     render_manifests,
 )
@@ -132,7 +126,8 @@ def test_hpa_annotations_render_when_enabled(helm_runner) -> None:
             "autoscaling": {
                 "enabled": True,
                 "annotations": {"argocd.argoproj.io/sync-wave": "10"},
-            }
+            },
+            "resources": {"requests": {"cpu": "100m"}},
         },
     )
 
@@ -141,79 +136,170 @@ def test_hpa_annotations_render_when_enabled(helm_runner) -> None:
     }
 
 
-@pytest.mark.parametrize(
-    "values",
-    [
-        pytest.param(
-            {
-                "autoscaling": {
-                    "enabled": True,
-                    "hpaScalingRules": [
-                        {
-                            "name": "myapp_queue_depth",
-                            "target": {"averageValue": "100"},
-                        }
-                    ],
-                }
-            },
-            id="scaling-rule-missing-expr",
-        ),
-        pytest.param(
-            {
-                "autoscaling": {
-                    "enabled": True,
-                    "hpaScalingRules": [
-                        {
-                            "name": "myapp-queue-depth",
-                            "expr": "vector(1)",
-                            "target": {"averageValue": "100"},
-                        }
-                    ],
-                }
-            },
-            id="invalid-metric-name",
-        ),
-        pytest.param(
-            {
-                "autoscaling": {
-                    "enabled": True,
-                    "hpaScalingRules": [
-                        {
-                            "name": "myapp_queue_depth",
-                            "expr": "vector(1)",
-                            "labels": {"queue": 1},
-                            "target": {"averageValue": "100"},
-                        }
-                    ],
-                }
-            },
-            id="scaling-rule-label-is-not-string",
-        ),
-        pytest.param(
-            {
-                "autoscaling": {
-                    "enabled": True,
-                    "hpaScalingRules": [
-                        {
-                            "name": "myapp_queue_depth",
-                            "expr": "vector(1)",
-                            "target": {
-                                "type": "Utilization",
-                                "averageValue": "100",
-                            },
-                        }
-                    ],
-                }
-            },
-            id="invalid-target-type",
-        ),
-    ],
-)
-def test_hpa_schema_rejects_invalid_values(
-    helm_runner,
-    values: dict[str, Any],
-) -> None:
-    """Reject malformed HPA scaling rules."""
+def test_horizontal_uses_native_autoscaling_v2_metrics(helm_runner) -> None:
+    """Pass every stable autoscaling/v2 MetricSpec source through unchanged."""
 
-    with pytest.raises(HelmTemplateError):
-        render_chart(helm_runner, CHART, values=values)
+    metrics = [
+        {
+            "type": "Resource",
+            "resource": {
+                "name": "cpu",
+                "target": {
+                    "type": "Utilization",
+                    "averageUtilization": 70,
+                },
+            },
+        },
+        {
+            "type": "ContainerResource",
+            "containerResource": {
+                "name": "memory",
+                "container": "universal-chart",
+                "target": {
+                    "type": "AverageValue",
+                    "averageValue": "512Mi",
+                },
+            },
+        },
+        {
+            "type": "External",
+            "external": {
+                "metric": {
+                    "name": "queue_depth",
+                    "selector": {"matchLabels": {"queue": "critical"}},
+                },
+                "target": {"type": "Value", "value": "100"},
+            },
+        },
+        {
+            "type": "Object",
+            "object": {
+                "describedObject": {
+                    "apiVersion": "networking.k8s.io/v1",
+                    "kind": "Ingress",
+                    "name": "example",
+                },
+                "metric": {"name": "requests_per_second"},
+                "target": {"type": "Value", "value": "1k"},
+            },
+        },
+        {
+            "type": "Pods",
+            "pods": {
+                "metric": {"name": "packets_per_second"},
+                "target": {"type": "AverageValue", "averageValue": "1k"},
+            },
+        },
+    ]
+    hpa = render_manifest(
+        helm_runner,
+        "HorizontalPodAutoscaler",
+        values={
+            "autoscaling": {
+                "horizontal": {
+                    "enabled": True,
+                    "minReplicas": 2,
+                    "maxReplicas": 12,
+                    "metrics": metrics,
+                }
+            },
+            "resources": {"requests": {"cpu": "100m"}},
+        },
+    )
+
+    assert hpa["apiVersion"] == "autoscaling/v2"
+    assert hpa["spec"]["metrics"] == metrics
+
+
+def test_horizontal_metrics_replace_legacy_resource_targets(
+    helm_runner,
+) -> None:
+    """Use an explicitly supplied native metrics list instead of legacy CPU."""
+
+    external_metric = {
+        "type": "External",
+        "external": {
+            "metric": {"name": "queue_depth"},
+            "target": {"type": "AverageValue", "averageValue": "20"},
+        },
+    }
+    hpa = render_manifest(
+        helm_runner,
+        "HorizontalPodAutoscaler",
+        values={
+            "autoscaling": {
+                "enabled": True,
+                "targetCPUUtilizationPercentage": 80,
+                "horizontal": {"metrics": [external_metric]},
+            }
+        },
+    )
+
+    assert hpa["spec"]["metrics"] == [external_metric]
+
+
+def test_horizontal_disabled_overrides_legacy_enabled(helm_runner) -> None:
+    """Keep fixed replicas when the preferred interface disables legacy HPA."""
+
+    manifests = render_manifests(
+        helm_runner,
+        values={
+            "replicaCount": 3,
+            "autoscaling": {
+                "enabled": True,
+                "horizontal": {"enabled": False},
+            },
+        },
+    )
+
+    assert all(item["kind"] != "HorizontalPodAutoscaler" for item in manifests)
+    deployment = get_manifest(manifests, "Deployment")
+    assert deployment["spec"]["replicas"] == 3
+
+
+def test_horizontal_prometheus_rules_override_and_append(helm_runner) -> None:
+    """Replace legacy rules and append generated metrics to native metrics."""
+
+    native_metric = {
+        "type": "External",
+        "external": {
+            "metric": {"name": "native_queue_depth"},
+            "target": {"type": "Value", "value": "50"},
+        },
+    }
+    hpa = render_manifest(
+        helm_runner,
+        "HorizontalPodAutoscaler",
+        values={
+            "autoscaling": {
+                "enabled": True,
+                "targetCPUUtilizationPercentage": None,
+                "hpaScalingRules": [
+                    {
+                        "name": "legacy_metric",
+                        "expr": "vector(1)",
+                        "target": {"averageValue": "1"},
+                    }
+                ],
+                "horizontal": {
+                    "metrics": [native_metric],
+                    "prometheusScalingRules": [
+                        {
+                            "name": "preferred_metric",
+                            "expr": "vector(2)",
+                            "target": {"averageValue": "2"},
+                        }
+                    ],
+                },
+            }
+        },
+    )
+
+    names = [
+        metric["external"]["metric"]["name"]
+        for metric in hpa["spec"]["metrics"]
+    ]
+    assert names == [
+        "native_queue_depth",
+        "preferred_metric",
+    ]

--- a/tests/test_universal_chart_hpa_validation.py
+++ b/tests/test_universal_chart_hpa_validation.py
@@ -1,0 +1,348 @@
+"""HorizontalPodAutoscaler validation tests for universal-chart."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from .chart_test_utils import render_chart
+from .conftest import HelmTemplateError
+from .universal_chart_test_utils import CHART, render_manifest
+
+CPU_UTILIZATION_METRIC = {
+    "type": "Resource",
+    "resource": {
+        "name": "cpu",
+        "target": {"type": "Utilization", "averageUtilization": 80},
+    },
+}
+
+
+@pytest.mark.parametrize(
+    ("values", "message"),
+    [
+        pytest.param(
+            {
+                "autoscaling": {
+                    "horizontal": {
+                        "enabled": True,
+                        "metrics": [],
+                        "prometheusScalingRules": [],
+                    }
+                }
+            },
+            "requires at least one metric",
+            id="enabled-without-metrics",
+        ),
+        pytest.param(
+            {
+                "autoscaling": {
+                    "horizontal": {
+                        "enabled": True,
+                        "minReplicas": 5,
+                        "maxReplicas": 2,
+                        "metrics": [
+                            {
+                                "type": "External",
+                                "external": {
+                                    "metric": {"name": "queue_depth"},
+                                    "target": {
+                                        "type": "Value",
+                                        "value": "10",
+                                    },
+                                },
+                            }
+                        ],
+                    }
+                }
+            },
+            "minReplicas",
+            id="minimum-exceeds-maximum",
+        ),
+        pytest.param(
+            {
+                "autoscaling": {
+                    "horizontal": {
+                        "enabled": True,
+                        "metrics": [CPU_UTILIZATION_METRIC],
+                    }
+                }
+            },
+            "requires resources.requests.cpu",
+            id="native-cpu-utilization-without-request",
+        ),
+        pytest.param(
+            {
+                "autoscaling": {
+                    "horizontal": {
+                        "enabled": True,
+                        "metrics": [
+                            {
+                                "type": "ContainerResource",
+                                "containerResource": {
+                                    "name": "memory",
+                                    "container": "universal-chart",
+                                    "target": {
+                                        "type": "Utilization",
+                                        "averageUtilization": 70,
+                                    },
+                                },
+                            }
+                        ],
+                    }
+                }
+            },
+            "requires resources.requests.memory",
+            id="container-utilization-without-request",
+        ),
+    ],
+)
+def test_horizontal_rejects_cross_field_misconfiguration(
+    helm_runner,
+    values: dict[str, Any],
+    message: str,
+) -> None:
+    """Fail before creating an inert or invalid HPA."""
+
+    with pytest.raises(HelmTemplateError, match=message):
+        render_chart(helm_runner, CHART, values=values)
+
+
+def test_legacy_utilization_renders_without_declared_requests(
+    helm_runner,
+) -> None:
+    """Keep releases that predate autoscaling.horizontal renderable."""
+
+    hpa = render_manifest(
+        helm_runner,
+        "HorizontalPodAutoscaler",
+        values={"autoscaling": {"enabled": True, "maxReplicas": 6}},
+    )
+
+    assert hpa["spec"]["metrics"] == [CPU_UTILIZATION_METRIC]
+
+
+def test_horizontal_accepts_request_from_extra_container_props(
+    helm_runner,
+) -> None:
+    """Validate utilization against the resources rendered on the container."""
+
+    rendered = render_chart(
+        helm_runner,
+        CHART,
+        values={
+            "extraContainerProps": {"resources": {"requests": {"cpu": "100m"}}},
+            "autoscaling": {
+                "horizontal": {
+                    "enabled": True,
+                    "metrics": [CPU_UTILIZATION_METRIC],
+                }
+            },
+        },
+    )
+
+    assert "kind: HorizontalPodAutoscaler" in rendered
+
+
+def test_horizontal_uses_extra_container_resource_precedence(
+    helm_runner,
+) -> None:
+    """Reject a request hidden by the explicit extra-container override."""
+
+    with pytest.raises(
+        HelmTemplateError,
+        match=r"requires resources\.requests\.cpu",
+    ):
+        render_chart(
+            helm_runner,
+            CHART,
+            values={
+                "resources": {"requests": {"cpu": "100m"}},
+                "extraContainerProps": {
+                    "resources": {"requests": {"memory": "128Mi"}}
+                },
+                "autoscaling": {
+                    "horizontal": {
+                        "enabled": True,
+                        "metrics": [CPU_UTILIZATION_METRIC],
+                    }
+                },
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param(
+            {
+                "autoscaling": {
+                    "enabled": True,
+                    "hpaScalingRules": [
+                        {
+                            "name": "myapp_queue_depth",
+                            "target": {"averageValue": "100"},
+                        }
+                    ],
+                }
+            },
+            id="scaling-rule-missing-expr",
+        ),
+        pytest.param(
+            {
+                "autoscaling": {
+                    "enabled": True,
+                    "hpaScalingRules": [
+                        {
+                            "name": "myapp-queue-depth",
+                            "expr": "vector(1)",
+                            "target": {"averageValue": "100"},
+                        }
+                    ],
+                }
+            },
+            id="invalid-metric-name",
+        ),
+        pytest.param(
+            {
+                "autoscaling": {
+                    "enabled": True,
+                    "hpaScalingRules": [
+                        {
+                            "name": "myapp_queue_depth",
+                            "expr": "vector(1)",
+                            "labels": {"queue": 1},
+                            "target": {"averageValue": "100"},
+                        }
+                    ],
+                }
+            },
+            id="scaling-rule-label-is-not-string",
+        ),
+        pytest.param(
+            {
+                "autoscaling": {
+                    "enabled": True,
+                    "hpaScalingRules": [
+                        {
+                            "name": "myapp_queue_depth",
+                            "expr": "vector(1)",
+                            "target": {
+                                "type": "Utilization",
+                                "averageValue": "100",
+                            },
+                        }
+                    ],
+                }
+            },
+            id="invalid-target-type",
+        ),
+        pytest.param(
+            {
+                "autoscaling": {
+                    "horizontal": {
+                        "annotations": {
+                            "argocd.argoproj.io/sync-wave": 10,
+                        }
+                    }
+                }
+            },
+            id="horizontal-annotation-is-not-string",
+        ),
+        pytest.param(
+            {
+                "autoscaling": {
+                    "horizontal": {
+                        "behavior": {
+                            "scaleUp": {
+                                "policies": [
+                                    {
+                                        "type": "Percent",
+                                        "value": 100,
+                                        "periodSeconds": 0,
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+            id="horizontal-behavior-period-out-of-range",
+        ),
+        pytest.param(
+            {
+                "autoscaling": {
+                    "horizontal": {
+                        "metrics": [
+                            {
+                                "type": "Resource",
+                                "external": {
+                                    "metric": {"name": "queue_depth"},
+                                    "target": {
+                                        "type": "Value",
+                                        "value": "10",
+                                    },
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+            id="metric-discriminator-does-not-match-source",
+        ),
+        pytest.param(
+            {
+                "autoscaling": {
+                    "horizontal": {
+                        "metrics": [
+                            {
+                                "type": "External",
+                                "external": {
+                                    "metric": {"name": "queue_depth"},
+                                    "target": {
+                                        "type": "AverageValue",
+                                        "averageValue": "not-a-quantity",
+                                    },
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+            id="native-metric-target-is-not-a-quantity",
+        ),
+        pytest.param(
+            {
+                "autoscaling": {
+                    "horizontal": {
+                        "behavior": {"scaleUp": {"tolerance": "not-a-quantity"}}
+                    }
+                }
+            },
+            id="behavior-tolerance-is-not-a-quantity",
+        ),
+        pytest.param(
+            {
+                "autoscaling": {
+                    "hpaScalingRules": [
+                        {
+                            "name": "myapp_queue_depth",
+                            "expr": "vector(1)",
+                            "target": {"averageValue": "not-a-quantity"},
+                        }
+                    ]
+                }
+            },
+            id="legacy-prometheus-target-is-not-a-quantity",
+        ),
+    ],
+)
+def test_hpa_schema_rejects_invalid_values(
+    helm_runner,
+    values: dict[str, Any],
+) -> None:
+    """Reject malformed HPA values before template rendering."""
+
+    with pytest.raises(HelmTemplateError):
+        render_chart(helm_runner, CHART, values=values)

--- a/tests/test_universal_chart_pdb.py
+++ b/tests/test_universal_chart_pdb.py
@@ -38,6 +38,7 @@ def _pdb_values(
             "enabled": True,
             "minReplicas": autoscaling_min,
         }
+        values["resources"] = {"requests": {"cpu": "100m"}}
     return values
 
 
@@ -306,6 +307,41 @@ def test_pod_disruption_budget_uses_autoscaling_min_replicas(
     pdb = get_manifest(load_manifests(rendered), "PodDisruptionBudget")
 
     assert pdb["spec"]["minAvailable"] == 1
+
+
+def test_pod_disruption_budget_uses_horizontal_min_replicas(
+    helm_runner,
+) -> None:
+    """Use the preferred horizontal minimum for disruption validation."""
+
+    values = {
+        "replicaCount": 1,
+        "podDisruptionBudget": {
+            "enabled": True,
+            "minAvailable": 2,
+            "allowZeroDisruptions": True,
+        },
+        "autoscaling": {
+            "minReplicas": 1,
+            "horizontal": {
+                "enabled": True,
+                "minReplicas": 2,
+                "metrics": [
+                    {
+                        "type": "External",
+                        "external": {
+                            "metric": {"name": "queue_depth"},
+                            "target": {"type": "Value", "value": "10"},
+                        },
+                    }
+                ],
+            },
+        },
+    }
+    rendered = render_chart(helm_runner, CHART, values=values)
+    pdb = get_manifest(load_manifests(rendered), "PodDisruptionBudget")
+
+    assert pdb["spec"]["minAvailable"] == 2
 
 
 def test_pod_disruption_budget_is_not_rendered_when_disabled(

--- a/tests/test_universal_chart_vpa.py
+++ b/tests/test_universal_chart_vpa.py
@@ -1,0 +1,389 @@
+"""VerticalPodAutoscaler tests for universal-chart."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from .chart_test_utils import render_chart
+from .conftest import HelmTemplateError
+from .universal_chart_test_utils import (
+    CHART,
+    render_manifest,
+    render_manifests,
+)
+
+
+def test_vpa_is_absent_by_default(helm_runner) -> None:
+    """Do not require VPA CRDs for workloads that have not opted in."""
+
+    manifests = render_manifests(helm_runner)
+
+    assert all(item["kind"] != "VerticalPodAutoscaler" for item in manifests)
+
+
+def test_vpa_off_renders_safe_recommendation_policy(helm_runner) -> None:
+    """Create recommendation-only VPA with bounded resource ownership."""
+
+    vpa = render_manifest(
+        helm_runner,
+        "VerticalPodAutoscaler",
+        values={
+            "autoscaling": {
+                "vertical": {
+                    "enabled": True,
+                    "annotations": {"argocd.argoproj.io/sync-wave": "10"},
+                }
+            }
+        },
+    )
+
+    assert vpa["apiVersion"] == "autoscaling.k8s.io/v1"
+    assert vpa["metadata"]["annotations"] == {
+        "argocd.argoproj.io/sync-wave": "10"
+    }
+    assert vpa["spec"]["targetRef"] == {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "name": "universal-chart",
+    }
+    assert vpa["spec"]["updatePolicy"] == {
+        "updateMode": "Off",
+        "minReplicas": 2,
+    }
+    assert vpa["spec"]["resourcePolicy"]["containerPolicies"] == [
+        {
+            "containerName": "*",
+            "mode": "Auto",
+            "controlledResources": ["cpu", "memory"],
+            "controlledValues": "RequestsOnly",
+            "minAllowed": {},
+            "maxAllowed": {},
+        }
+    ]
+
+
+@pytest.mark.parametrize("mode", ["Initial", "Recreate", "InPlaceOrRecreate"])
+def test_vpa_active_modes_render_with_explicit_ceilings(
+    helm_runner,
+    mode: str,
+) -> None:
+    """Render every supported mutating mode when resource ceilings are set."""
+
+    policies = [
+        {
+            "containerName": "*",
+            "mode": "Auto",
+            "controlledResources": ["cpu", "memory"],
+            "controlledValues": "RequestsOnly",
+            "minAllowed": {"cpu": "50m", "memory": "64Mi"},
+            "maxAllowed": {"cpu": "2", "memory": "2Gi"},
+        }
+    ]
+    vpa = render_manifest(
+        helm_runner,
+        "VerticalPodAutoscaler",
+        values={
+            "autoscaling": {
+                "vertical": {
+                    "enabled": True,
+                    "updatePolicy": {"updateMode": mode, "minReplicas": 3},
+                    "resourcePolicy": {"containerPolicies": policies},
+                }
+            }
+        },
+    )
+
+    assert vpa["spec"]["updatePolicy"] == {
+        "updateMode": mode,
+        "minReplicas": 3,
+    }
+    assert vpa["spec"]["resourcePolicy"]["containerPolicies"] == policies
+
+
+@pytest.mark.parametrize(
+    ("vertical", "message"),
+    [
+        pytest.param(
+            {
+                "enabled": True,
+                "updatePolicy": {
+                    "updateMode": "Recreate",
+                    "minReplicas": 2,
+                },
+                "resourcePolicy": {
+                    "containerPolicies": [
+                        {
+                            "containerName": "*",
+                            "mode": "Auto",
+                            "controlledResources": ["cpu", "memory"],
+                            "controlledValues": "RequestsOnly",
+                            "maxAllowed": {"cpu": "1"},
+                        }
+                    ]
+                },
+            },
+            "requires maxAllowed.memory",
+            id="missing-memory-ceiling",
+        ),
+        pytest.param(
+            {
+                "enabled": True,
+                "updatePolicy": {
+                    "updateMode": "Initial",
+                    "minReplicas": 2,
+                },
+                "resourcePolicy": {"containerPolicies": []},
+            },
+            "require at least one containerPolicy",
+            id="active-without-policies",
+        ),
+        pytest.param(
+            {
+                "enabled": True,
+                "resourcePolicy": {
+                    "containerPolicies": [
+                        {
+                            "containerName": "*",
+                            "controlledResources": ["cpu"],
+                            "controlledValues": "RequestsOnly",
+                        },
+                        {
+                            "containerName": "*",
+                            "controlledResources": ["memory"],
+                            "controlledValues": "RequestsOnly",
+                        },
+                    ]
+                },
+            },
+            "duplicate containerName",
+            id="duplicate-container-policy",
+        ),
+    ],
+)
+def test_vpa_rejects_unsafe_policy_combinations(
+    helm_runner,
+    vertical: dict[str, Any],
+    message: str,
+) -> None:
+    """Reject active policies without ownership and safety bounds."""
+
+    with pytest.raises(HelmTemplateError, match=message):
+        render_chart(
+            helm_runner,
+            CHART,
+            values={"autoscaling": {"vertical": vertical}},
+        )
+
+
+def test_vpa_schema_rejects_malformed_resource_quantity(helm_runner) -> None:
+    """Reject malformed resource bounds before Kubernetes admission."""
+
+    with pytest.raises(HelmTemplateError):
+        render_chart(
+            helm_runner,
+            CHART,
+            values={
+                "autoscaling": {
+                    "vertical": {
+                        "enabled": True,
+                        "updatePolicy": {
+                            "updateMode": "Recreate",
+                            "minReplicas": 2,
+                        },
+                        "resourcePolicy": {
+                            "containerPolicies": [
+                                {
+                                    "containerName": "*",
+                                    "controlledResources": ["memory"],
+                                    "controlledValues": "RequestsOnly",
+                                    "maxAllowed": {"memory": "not-a-quantity"},
+                                }
+                            ]
+                        },
+                    }
+                }
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    ("resource", "minimum", "maximum"),
+    [
+        pytest.param("cpu", "1", "500m", id="cpu-decimal-si"),
+        pytest.param("memory", "1G", "999M", id="memory-decimal-si"),
+        pytest.param("memory", "1Gi", "512Mi", id="memory-binary-si"),
+    ],
+)
+def test_vpa_rejects_inverted_resource_bounds(
+    helm_runner,
+    resource: str,
+    minimum: str,
+    maximum: str,
+) -> None:
+    """Reject bounds that the VPA admission webhook would deny."""
+
+    with pytest.raises(HelmTemplateError, match="cannot exceed"):
+        render_chart(
+            helm_runner,
+            CHART,
+            values={
+                "autoscaling": {
+                    "vertical": {
+                        "enabled": True,
+                        "updatePolicy": {
+                            "updateMode": "Recreate",
+                            "minReplicas": 2,
+                        },
+                        "resourcePolicy": {
+                            "containerPolicies": [
+                                {
+                                    "containerName": "*",
+                                    "controlledResources": [resource],
+                                    "controlledValues": "RequestsOnly",
+                                    "minAllowed": {resource: minimum},
+                                    "maxAllowed": {resource: maximum},
+                                }
+                            ]
+                        },
+                    }
+                }
+            },
+        )
+
+
+@pytest.mark.parametrize("mode", ["Auto", "InPlace"])
+def test_vpa_schema_rejects_unsupported_update_modes(
+    helm_runner,
+    mode: str,
+) -> None:
+    """Reject deprecated or insufficiently portable VPA update modes."""
+
+    with pytest.raises(HelmTemplateError):
+        render_chart(
+            helm_runner,
+            CHART,
+            values={
+                "autoscaling": {
+                    "vertical": {
+                        "enabled": True,
+                        "updatePolicy": {
+                            "updateMode": mode,
+                            "minReplicas": 2,
+                        },
+                    }
+                }
+            },
+        )
+
+
+def test_active_vpa_rejects_resource_utilization_hpa(helm_runner) -> None:
+    """Prevent HPA and VPA from controlling the same CPU signal."""
+
+    with pytest.raises(HelmTemplateError, match="conflicts"):
+        render_chart(
+            helm_runner,
+            CHART,
+            values={
+                "resources": {"requests": {"cpu": "100m"}},
+                "autoscaling": {
+                    "horizontal": {
+                        "enabled": True,
+                        "metrics": [
+                            {
+                                "type": "Resource",
+                                "resource": {
+                                    "name": "cpu",
+                                    "target": {
+                                        "type": "Utilization",
+                                        "averageUtilization": 80,
+                                    },
+                                },
+                            }
+                        ],
+                    },
+                    "vertical": {
+                        "enabled": True,
+                        "updatePolicy": {
+                            "updateMode": "Recreate",
+                            "minReplicas": 2,
+                        },
+                        "resourcePolicy": {
+                            "containerPolicies": [
+                                {
+                                    "containerName": "*",
+                                    "controlledResources": ["cpu"],
+                                    "controlledValues": "RequestsOnly",
+                                    "maxAllowed": {"cpu": "2"},
+                                }
+                            ]
+                        },
+                    },
+                },
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [
+        pytest.param(
+            {
+                "type": "External",
+                "external": {
+                    "metric": {"name": "queue_depth"},
+                    "target": {"type": "AverageValue", "averageValue": "20"},
+                },
+            },
+            id="external",
+        ),
+        pytest.param(
+            {
+                "type": "Resource",
+                "resource": {
+                    "name": "cpu",
+                    "target": {
+                        "type": "AverageValue",
+                        "averageValue": "200m",
+                    },
+                },
+            },
+            id="raw-resource-value",
+        ),
+    ],
+)
+def test_active_vpa_allows_compatible_hpa_metrics(
+    helm_runner,
+    metric: dict[str, Any],
+) -> None:
+    """Allow HPA signals that do not depend on VPA-managed request ratios."""
+
+    manifests = render_manifests(
+        helm_runner,
+        values={
+            "autoscaling": {
+                "horizontal": {"enabled": True, "metrics": [metric]},
+                "vertical": {
+                    "enabled": True,
+                    "updatePolicy": {
+                        "updateMode": "Recreate",
+                        "minReplicas": 2,
+                    },
+                    "resourcePolicy": {
+                        "containerPolicies": [
+                            {
+                                "containerName": "*",
+                                "controlledResources": ["cpu"],
+                                "controlledValues": "RequestsOnly",
+                                "maxAllowed": {"cpu": "2"},
+                            }
+                        ]
+                    },
+                },
+            }
+        },
+    )
+
+    kinds = {item["kind"] for item in manifests}
+    assert {"HorizontalPodAutoscaler", "VerticalPodAutoscaler"} <= kinds


### PR DESCRIPTION
## Summary

Adds production-ready horizontal and vertical pod autoscaling to `universal-chart`, with strict validation, backward compatibility, and self-service documentation.

## What changed

- Added `autoscaling.horizontal`, built on stable Kubernetes `autoscaling/v2`.
- Added native support for Resource, ContainerResource, External, Object, and Pods metrics.
- Added `autoscaling.vertical` using `autoscaling.k8s.io/v1`.
- Preserved the legacy `autoscaling.*` HPA interface.
- Added explicit new-over-legacy precedence rules.
- Centralized autoscaling configuration for HPA, Deployment replicas, PDB sizing, and Prometheus rules.
- Added VPA recommendation-only mode as the safe default.
- Added support for `Initial`, `Recreate`, and `InPlaceOrRecreate` VPA modes.
- Added validation for:
  - enabled HPAs without metrics
  - missing resource requests for utilization metrics
  - invalid replica bounds
  - malformed HPA metrics and behavior policies
  - active VPA policies without resource ceilings
  - duplicate VPA container policies
  - conflicting HPA utilization metrics and VPA-controlled resources
- Added HPA v2 and VPA fixtures, golden files, and focused tests.
- Added a self-service autoscaling guide covering prerequisites, examples, migration, verification, troubleshooting, rollout, and rollback.
- Regenerated the values schema and chart README.

## Compatibility

Existing HPA configurations remain supported.

Keys explicitly supplied under `autoscaling.horizontal` override their legacy equivalents. Omitted keys continue to inherit legacy values, allowing incremental migration.

The chart does not install Metrics Server, VPA components, Prometheus Operator, or a metrics adapter. These remain cluster-level prerequisites.

## Safety defaults

- VPA is disabled by default.
- Enabling VPA defaults to recommendation-only mode (`Off`).
- Active VPA modes require `maxAllowed` ceilings for every controlled resource.
- VPA defaults to `RequestsOnly`.
- Deprecated VPA `Auto` and direct `InPlace` modes are rejected.
- HPA/VPA utilization feedback loops are rejected during rendering.
- Deployment replicas are removed only when a valid effective HPA is enabled.

## Validation

- [x] Full test suite: `242 passed`
- [x] All pre-commit hooks
- [x] Helm lint with Helm `4.1.1`
- [x] Strict MkDocs/TechDocs build
- [x] HPA manifest validation with kubeconform
- [x] VPA manifest shape covered by rendering and golden tests
- [x] Schema regeneration is idempotent
- [x] Thermo-nuclear code-quality review
- [x] Scorched-earth documentation review
- [x] No remaining P1/high-priority review findings
- [x] `git diff --check`

## Release notes

The chart retains version `0.0.0-a.placeholder`; release automation will assign the published version.