### PR TITLE
feat(universal-chart): support extra (sidecar) containers

### DIFF
--- a/charts/universal-chart/README.md
+++ b/charts/universal-chart/README.md
@@ -129,6 +129,142 @@ deployment:
 
 An explicit annotation takes precedence even when `reloader.enabled` is true.
 
+## Extra containers (sidecars)
+
+Some apps need a second container in the same pod: a queue worker built from
+the app image, a proxy the app talks to over localhost, or a metrics exporter.
+`extraContainers` adds them. Each entry needs a unique `name` and an `image`
+with `repository` plus exactly one of `tag` or `digest` — the same rule as the
+main image. Every container in the pod uses the chart-wide `image.pullPolicy`.
+
+There are two common cases, and the defaults favor the first one.
+
+A **same-image companion** wants the app's environment. By default each entry
+inherits the main container's `env` and `envFrom` (one switch covers both) and
+its `volumeMounts`. Anything you set on the entry is merged on top and wins on
+conflict — env vars by name, mounts by `mountPath`:
+
+```yaml
+extraContainers:
+  - name: worker
+    image:
+      repository: ghcr.io/example/app
+      tag: "1.2.3"
+    command: ["pnpm"]
+    args: ["run", "worker"]
+    env:
+      ROLE: worker   # everything else comes from the main container
+```
+
+A **third-party helper** usually shouldn't see the app's secrets. Set
+`inheritEnv: false` and it gets only what you give it, through `env`,
+`envFromSecrets`, and `envFromConfigmaps`. The same idea applies to
+`inheritVolumeMounts: false`. An empty `securityContext` falls back to the
+top-level one; setting any field replaces it entirely, because a partially
+merged security context is hard to reason about:
+
+```yaml
+extraContainers:
+  - name: oauth2-proxy
+    image:
+      repository: quay.io/oauth2-proxy/oauth2-proxy
+      tag: v7.6.0
+    inheritEnv: false
+    envFromSecrets:
+      - proxy-creds
+    securityContext:
+      runAsUser: 2000
+    ports:
+      - name: proxy
+        containerPort: 4180
+```
+
+Each entry takes its own `resources`, probes (`startupProbe`,
+`livenessProbe`, `readinessProbe`), `ports`, `command`, and `args`. For
+container fields the chart doesn't model, such as `lifecycle` or
+`workingDir`, use `extraContainerProps`. Port names must be unique across the
+whole pod, so a sidecar port can't be called `http` or reuse a name from
+`extraContainerPorts`.
+
+> [!WARNING]
+> A failing `readinessProbe` on *any* container removes the whole pod from
+> its Service. That's useful when the app shouldn't get traffic before its
+> proxy is up, and painful when a flaky exporter probe takes down a healthy
+> app. Give a sidecar a readiness probe only when its readiness should gate
+> traffic.
+
+### Native sidecars
+
+Set `nativeSidecar: true` when the app depends on the sidecar at startup or
+shutdown — a database proxy is the classic case. The entry is rendered as an
+init container with `restartPolicy: Always`, so it starts before everything
+else, keeps running, and stops after the main container exits. The chart
+places native sidecars ahead of `initContainers` entries, and a native
+sidecar's `startupProbe` holds everything after it, so a migration init
+container can rely on the proxy being up before it runs.
+
+> [!WARNING]
+> Native sidecars need Kubernetes 1.28 or newer. The chart doesn't check the
+> cluster version; on an older cluster the pod is rejected at admission with
+> an error about `restartPolicy` on an init container.
+
+```yaml
+extraContainers:
+  - name: sql-proxy
+    nativeSidecar: true
+    inheritEnv: false
+    image:
+      repository: gcr.io/cloud-sql-connectors/cloud-sql-proxy
+      tag: "2.14.0"
+    startupProbe:
+      httpGet:
+        path: /startup
+        port: 9801
+```
+
+### Autoscaling with sidecars
+
+> [!WARNING]
+> The chart's CPU and memory autoscaling targets average utilization across
+> **all** containers in the pod. A sidecar with a generous request and low
+> usage drags the average down, so the app scales up later than it should.
+> Keep sidecar requests small relative to the main container, or scale on an
+> external metric through `autoscaling.hpaScalingRules` instead. If you need
+> scaling pinned to the main container by name (the `ContainerResource`
+> metric type), ask Infrastructure — it's a known follow-up.
+
+### Exposing a sidecar port
+
+Nothing new is needed. Point a Service port at the sidecar's named container
+port with `service.extraPorts`, and scrape it with
+`serviceMonitor.alternatePort`. A metrics exporter looks like this:
+
+```yaml
+extraContainers:
+  - name: exporter
+    image:
+      repository: ghcr.io/example/exporter
+      tag: "1.0.0"
+    inheritEnv: false
+    ports:
+      - name: exp-metrics
+        containerPort: 9187
+
+service:
+  extraPorts:
+    - name: exp-metrics
+      port: 9187
+      targetPort: exp-metrics
+
+serviceMonitor:
+  enabled: true
+  alternatePort: 9187
+```
+
+One thing `extraContainers` is not for: a second workload that scales on its
+own. Sidecars share the pod's replica count and HPA. A worker that needs its
+own scaling is its own release of this chart.
+
 ## Using The Chart
 
 Normally, you're going to want to distribute this chart via ArgoCD as an
@@ -300,6 +436,7 @@ helm template my-release . \
 | deployment.annotations | object | `{}` | extra annotations to add to the deployment resource's metadata. These annotations are key-value pairs attached directly to the Deployment resource. They can be used by external tooling, operators, or for tracking deployment metadata and events. For more info, see: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
 | extraContainerPorts | list | `[]` | extra ports to be exposed directly from pods (no service) |
 | extraContainerProps | object | `{}` | A dictionary of extra attributes to add to the container spec in the deployment. Elements will be directly added to the deployment's `spec.template.spec.containers` object. Note that adding an element already in the deployment template like `env` or `image` will cause undesirable behavior. |
+| extraContainers | list | `[]` | Additional long-running (sidecar) containers to run in the same pod as the main container. Each entry needs a unique `name` and an `image` with `repository` plus exactly one of `tag` or `digest` (the same rule as the main image). All containers share the chart-wide `image.pullPolicy`. By default every entry inherits the main container's environment (env and envFrom) and volume mounts; per-entry `env` and `volumeMounts` values are merged on top and win on conflicts (env by name, mounts by mountPath). Set `inheritEnv: false` or `inheritVolumeMounts: false` to start from a clean slate instead — recommended for third-party images that don't need the app's secrets. An empty `securityContext` inherits the top-level `securityContext`; a non-empty one replaces it entirely. Set `nativeSidecar: true` to render the entry as a native sidecar (an init container with `restartPolicy: Always`, Kubernetes 1.28+) that starts before init containers and the main container, and stops after them. Container port names must be unique across the whole pod, so sidecar port names cannot reuse `http` or names from `extraContainerPorts`. Use `extraContainerProps` for container fields the chart doesn't model, such as `lifecycle` or `workingDir`. |
 | extraEnvConfigmaps | list | `[]` | extra configmaps to load into environment |
 | extraEnvSecrets | list | `[]` | extra secrets to load into environment |
 | extraEnvVars | object | `{}` | additional environment variables and their values. Supports both simple string values and complex objects with valueFrom. |
@@ -396,6 +533,7 @@ helm template my-release . \
 | topologySpreadConstraints | list | `[{"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"}]` | When deploying with multiple replicas, spread pods around using these rules. The default is to spread pods evenly among the Availability Zones defined in the cluster. With a Karpenter-managed EKS cluster (like HeroDevs uses), there will usually be 3 AZs in a region where a cluster is deployed. If a constraint omits labelSelector, the chart injects selector labels. When the availability preset is enabled, it replaces custom zone and hostname constraints so each topology key appears only once. |
 | volumeMounts | list | `[]` | Additional volumes to mount |
 | volumes | list | `[]` | Additional volumes to create |
+
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/universal-chart/README.md.gotmpl
+++ b/charts/universal-chart/README.md.gotmpl
@@ -128,6 +128,142 @@ deployment:
 
 An explicit annotation takes precedence even when `reloader.enabled` is true.
 
+## Extra containers (sidecars)
+
+Some apps need a second container in the same pod: a queue worker built from
+the app image, a proxy the app talks to over localhost, or a metrics exporter.
+`extraContainers` adds them. Each entry needs a unique `name` and an `image`
+with `repository` plus exactly one of `tag` or `digest` — the same rule as the
+main image. Every container in the pod uses the chart-wide `image.pullPolicy`.
+
+There are two common cases, and the defaults favor the first one.
+
+A **same-image companion** wants the app's environment. By default each entry
+inherits the main container's `env` and `envFrom` (one switch covers both) and
+its `volumeMounts`. Anything you set on the entry is merged on top and wins on
+conflict — env vars by name, mounts by `mountPath`:
+
+```yaml
+extraContainers:
+  - name: worker
+    image:
+      repository: ghcr.io/example/app
+      tag: "1.2.3"
+    command: ["pnpm"]
+    args: ["run", "worker"]
+    env:
+      ROLE: worker   # everything else comes from the main container
+```
+
+A **third-party helper** usually shouldn't see the app's secrets. Set
+`inheritEnv: false` and it gets only what you give it, through `env`,
+`envFromSecrets`, and `envFromConfigmaps`. The same idea applies to
+`inheritVolumeMounts: false`. An empty `securityContext` falls back to the
+top-level one; setting any field replaces it entirely, because a partially
+merged security context is hard to reason about:
+
+```yaml
+extraContainers:
+  - name: oauth2-proxy
+    image:
+      repository: quay.io/oauth2-proxy/oauth2-proxy
+      tag: v7.6.0
+    inheritEnv: false
+    envFromSecrets:
+      - proxy-creds
+    securityContext:
+      runAsUser: 2000
+    ports:
+      - name: proxy
+        containerPort: 4180
+```
+
+Each entry takes its own `resources`, probes (`startupProbe`,
+`livenessProbe`, `readinessProbe`), `ports`, `command`, and `args`. For
+container fields the chart doesn't model, such as `lifecycle` or
+`workingDir`, use `extraContainerProps`. Port names must be unique across the
+whole pod, so a sidecar port can't be called `http` or reuse a name from
+`extraContainerPorts`.
+
+> [!WARNING]
+> A failing `readinessProbe` on *any* container removes the whole pod from
+> its Service. That's useful when the app shouldn't get traffic before its
+> proxy is up, and painful when a flaky exporter probe takes down a healthy
+> app. Give a sidecar a readiness probe only when its readiness should gate
+> traffic.
+
+### Native sidecars
+
+Set `nativeSidecar: true` when the app depends on the sidecar at startup or
+shutdown — a database proxy is the classic case. The entry is rendered as an
+init container with `restartPolicy: Always`, so it starts before everything
+else, keeps running, and stops after the main container exits. The chart
+places native sidecars ahead of `initContainers` entries, and a native
+sidecar's `startupProbe` holds everything after it, so a migration init
+container can rely on the proxy being up before it runs.
+
+> [!WARNING]
+> Native sidecars need Kubernetes 1.28 or newer. The chart doesn't check the
+> cluster version; on an older cluster the pod is rejected at admission with
+> an error about `restartPolicy` on an init container.
+
+```yaml
+extraContainers:
+  - name: sql-proxy
+    nativeSidecar: true
+    inheritEnv: false
+    image:
+      repository: gcr.io/cloud-sql-connectors/cloud-sql-proxy
+      tag: "2.14.0"
+    startupProbe:
+      httpGet:
+        path: /startup
+        port: 9801
+```
+
+### Autoscaling with sidecars
+
+> [!WARNING]
+> The chart's CPU and memory autoscaling targets average utilization across
+> **all** containers in the pod. A sidecar with a generous request and low
+> usage drags the average down, so the app scales up later than it should.
+> Keep sidecar requests small relative to the main container, or scale on an
+> external metric through `autoscaling.hpaScalingRules` instead. If you need
+> scaling pinned to the main container by name (the `ContainerResource`
+> metric type), ask Infrastructure — it's a known follow-up.
+
+### Exposing a sidecar port
+
+Nothing new is needed. Point a Service port at the sidecar's named container
+port with `service.extraPorts`, and scrape it with
+`serviceMonitor.alternatePort`. A metrics exporter looks like this:
+
+```yaml
+extraContainers:
+  - name: exporter
+    image:
+      repository: ghcr.io/example/exporter
+      tag: "1.0.0"
+    inheritEnv: false
+    ports:
+      - name: exp-metrics
+        containerPort: 9187
+
+service:
+  extraPorts:
+    - name: exp-metrics
+      port: 9187
+      targetPort: exp-metrics
+
+serviceMonitor:
+  enabled: true
+  alternatePort: 9187
+```
+
+One thing `extraContainers` is not for: a second workload that scales on its
+own. Sidecars share the pod's replica count and HPA. A worker that needs its
+own scaling is its own release of this chart.
+
 ## Using The Chart
 
 Normally, you're going to want to distribute this chart via ArgoCD as an

--- a/charts/universal-chart/docs/index.md
+++ b/charts/universal-chart/docs/index.md
@@ -27,6 +27,7 @@ Kubernetes primitives plus a small number of opinionated platform integrations.
 - optional Redis support
 - optional S3 bucket creation via ACK-backed resources
 - extra volumes and mounts
+- sidecar containers through `extraContainers`, including native sidecars
 - spread helpers for AZ and spot-aware scheduling
 - `terminationGracePeriodSeconds` for workloads that need slower shutdown
 
@@ -62,6 +63,26 @@ intentionally expose metrics publicly. If the public route differs from the
 in-cluster scrape path, set `serviceMonitor.blockExternalIngress.path`. When
 both the block path and `serviceMonitor.path` are null, the block path defaults
 to `/metrics`, matching Prometheus' default scrape path.
+
+## Extra Containers
+
+Use `extraContainers` when the app needs a second container in the same pod:
+a queue worker from the app image, a proxy, or a metrics exporter. Entries
+inherit the main container's environment and volume mounts by default, and
+per-entry values are merged on top. Set `inheritEnv: false` for third-party
+images that shouldn't see the app's secrets. Set `nativeSidecar: true`
+(Kubernetes 1.28+) when the app depends on the sidecar at startup or
+shutdown.
+
+Two behaviors surprise people: a failing readiness probe on any container
+removes the whole pod from its Service, and CPU/memory autoscaling averages
+utilization across all containers, so an oversized sidecar request delays
+scale-up. The [Generated Reference](reference.md) covers both, with examples
+for exposing a sidecar port through `service.extraPorts` and
+`serviceMonitor.alternatePort`.
+
+A sidecar shares the pod's replica count and HPA. A worker that needs its own
+scaling is its own release of this chart, not a sidecar.
 
 ## Recommended Ownership Split
 

--- a/charts/universal-chart/templates/_helpers.tpl
+++ b/charts/universal-chart/templates/_helpers.tpl
@@ -77,6 +77,188 @@ values schema.
 {{- end }}
 
 {{/*
+Render the environment variable list shared by the main container, init
+containers, and any extraContainers entries that inherit the environment.
+Pass the root context.
+*/}}
+{{- define "universal-chart.containerEnv" -}}
+# placeholder var so we can always make an env list
+- name: REDIS_ENABLED
+  value: {{ .Values.redis.enabled | quote }}
+{{- if .Values.redis.enabled }}
+- name: REDIS_USERNAME
+  value: default # oddly hard-coded in chart
+- name: REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ template "redis.secretName" .Subcharts.redis }}
+      key: {{ template "redis.secretPasswordKey" .Subcharts.redis }}
+- name: REDIS_PORT
+  value: {{ .Values.redis.master.containerPorts.redis | quote }}
+- name: REDIS_HOST
+  value: {{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) }}
+- name: REDIS_TLS
+  value: {{ .Values.redis.tls.enabled | quote }}
+{{- end }}
+{{- range $k, $v := .Values.extraEnvVars }}
+- name: {{ $k }}
+  {{- if kindIs "map" $v }}
+  {{- toYaml $v | nindent 2 }}
+  {{- else }}
+  value: {{ $v | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Render the envFrom list shared by the main container, init containers, and any
+extraContainers entries that inherit the environment. Empty output means the
+envFrom key should be omitted. Pass the root context.
+*/}}
+{{- define "universal-chart.containerEnvFrom" -}}
+{{- if .Values.awsEnvSecrets.externalSecret.secretPath }}
+- secretRef:
+    name: {{ .Values.awsEnvSecrets.env_secret_name }}
+{{- end }}
+{{- range .Values.extraEnvSecrets }}
+- secretRef:
+    name: {{ . }}
+{{- end }}
+{{- range .Values.extraEnvConfigmaps }}
+- configMapRef:
+    name: {{ . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Render the image reference for one extraContainers entry from the tag or
+digest selected by the values schema. Pass the entry's image map.
+*/}}
+{{- define "universal-chart.extraContainerImage" -}}
+{{- if .digest -}}
+{{- printf "%s@%s" .repository .digest -}}
+{{- else -}}
+{{- printf "%s:%s" .repository .tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render one extraContainers entry as a container spec list item.
+Pass (dict "root" $ "container" <entry> "native" <bool>). Native entries are
+rendered for the initContainers list and add restartPolicy: Always.
+*/}}
+{{- define "universal-chart.extraContainer" -}}
+{{- $root := .root -}}
+{{- $c := .container -}}
+{{- $native := .native | default false -}}
+{{- $inheritEnv := ternary $c.inheritEnv true (hasKey $c "inheritEnv") -}}
+{{- $inheritVolumeMounts := ternary $c.inheritVolumeMounts true (hasKey $c "inheritVolumeMounts") -}}
+- name: {{ $c.name }}
+  image: {{ include "universal-chart.extraContainerImage" $c.image | quote }}
+  imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+  {{- if $native }}
+  restartPolicy: Always
+  {{- end }}
+  {{- with $c.command }}
+  command:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $c.args }}
+  args:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $ownEnv := $c.env | default dict }}
+  {{- $env := list }}
+  {{- if $inheritEnv }}
+  {{- range (include "universal-chart.containerEnv" $root | fromYamlArray) }}
+  {{- if not (hasKey $ownEnv .name) }}
+  {{- $env = append $env . }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- range $k, $v := $ownEnv }}
+  {{- if kindIs "map" $v }}
+  {{- $env = append $env (merge (dict "name" $k) $v) }}
+  {{- else }}
+  {{- $env = append $env (dict "name" $k "value" ($v | toString)) }}
+  {{- end }}
+  {{- end }}
+  {{- with $env }}
+  env:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $envFrom := list }}
+  {{- if $inheritEnv }}
+  {{- with include "universal-chart.containerEnvFrom" $root | trim }}
+  {{- $envFrom = fromYamlArray . }}
+  {{- end }}
+  {{- end }}
+  {{- range ($c.envFromSecrets | default list) }}
+  {{- $envFrom = append $envFrom (dict "secretRef" (dict "name" .)) }}
+  {{- end }}
+  {{- range ($c.envFromConfigmaps | default list) }}
+  {{- $envFrom = append $envFrom (dict "configMapRef" (dict "name" .)) }}
+  {{- end }}
+  {{- with $envFrom }}
+  envFrom:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $securityContext := $c.securityContext | default dict }}
+  {{- if not $securityContext }}
+  {{- $securityContext = $root.Values.securityContext | default dict }}
+  {{- end }}
+  {{- with $securityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $c.ports }}
+  ports:
+    {{- range . }}
+    - name: {{ .name }}
+      containerPort: {{ .containerPort }}
+      protocol: {{ .protocol | default "TCP" }}
+    {{- end }}
+  {{- end }}
+  {{- with $c.startupProbe }}
+  startupProbe:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $c.livenessProbe }}
+  livenessProbe:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $c.readinessProbe }}
+  readinessProbe:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $c.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $ownMounts := $c.volumeMounts | default list }}
+  {{- $ownMountPaths := list }}
+  {{- range $ownMounts }}
+  {{- $ownMountPaths = append $ownMountPaths .mountPath }}
+  {{- end }}
+  {{- $mounts := list }}
+  {{- if $inheritVolumeMounts }}
+  {{- range ($root.Values.volumeMounts | default list) }}
+  {{- if not (has .mountPath $ownMountPaths) }}
+  {{- $mounts = append $mounts . }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- $mounts = concat $mounts $ownMounts }}
+  {{- with $mounts }}
+  volumeMounts:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $c.extraContainerProps }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}
+
+{{/*
 Render an External metric entry for a HorizontalPodAutoscaler.
 */}}
 {{- define "universal-chart.hpa.externalMetric" -}}
@@ -133,6 +315,11 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   metrics:
+    {{- /* TODO: the Resource metrics below average utilization across every
+    container in the pod, so extraContainers entries with resource requests
+    dilute the signal from the main container. If someone actually needs
+    sidecar-heavy pods to scale on the main container alone, add support for
+    the ContainerResource metric type (targets one container by name). */}}
     {{- if $root.Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:

--- a/charts/universal-chart/templates/deployment.yaml
+++ b/charts/universal-chart/templates/deployment.yaml
@@ -5,6 +5,35 @@ kind: Deployment
 {{- if and .Values.reloader.enabled (not (hasKey $deploymentAnnotations $reloadAnnotation)) }}
 {{- $_ := set $deploymentAnnotations $reloadAnnotation "true" }}
 {{- end }}
+{{- /* Detect whether the legacy initContainers block will render. */}}
+{{- $hasLegacyInit := false }}
+{{- with .Values.initContainers }}
+{{- if get (first .) "image" }}
+{{- $hasLegacyInit = true }}
+{{- end }}
+{{- end }}
+{{- /* Container names must be unique within the pod. Collect every name the
+chart generates, then fail fast on a collision instead of letting the API
+server reject the Deployment with a less helpful error. */}}
+{{- $containerNames := list .Chart.Name }}
+{{- if $hasLegacyInit }}
+{{- range $i, $_ := .Values.initContainers }}
+{{- $containerNames = append $containerNames (printf "init-%s-%d" $.Chart.Name $i) }}
+{{- end }}
+{{- end }}
+{{- $nativeSidecars := list }}
+{{- $regularSidecars := list }}
+{{- range .Values.extraContainers }}
+{{- if has .name $containerNames }}
+{{- fail (printf "extraContainers entry %q duplicates another container name in this pod (the main container is named %q and init containers are named init-%s-<index>); container names must be unique" .name $.Chart.Name $.Chart.Name) }}
+{{- end }}
+{{- $containerNames = append $containerNames .name }}
+{{- if .nativeSidecar }}
+{{- $nativeSidecars = append $nativeSidecars . }}
+{{- else }}
+{{- $regularSidecars = append $regularSidecars . }}
+{{- end }}
+{{- end }}
 metadata:
   name: {{ include "universal-chart.fullname" . }}
   labels:
@@ -47,50 +76,11 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          env: &containerenv
-            # placeholder var so we can always make an env list
-            - name: REDIS_ENABLED
-              value: {{ .Values.redis.enabled | quote }}
-            {{- if .Values.redis.enabled }}
-            - name: REDIS_USERNAME
-              value: default # oddly hard-coded in chart
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "redis.secretName" .Subcharts.redis }}
-                  key: {{ template "redis.secretPasswordKey" .Subcharts.redis }}
-            - name: REDIS_PORT
-              #value: {{ .Values.redis.master.service.ports.redis }}
-              value: {{ .Values.redis.master.containerPorts.redis | quote }}
-            - name: REDIS_HOST
-              value: {{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) }}
-            - name: REDIS_TLS
-              value: {{ .Values.redis.tls.enabled | quote }}
-            {{- end }}
-            {{- with .Values.extraEnvVars }}
-              {{- range $k, $v := . }}
-            - name: {{ $k }}
-              {{- if kindIs "map" $v }}
-              {{- toYaml $v | nindent 14 }}
-              {{- else }}
-              value: {{ $v | quote }}
-              {{- end }}
-              {{- end }}
-            {{- end }}
-          {{- if or .Values.awsEnvSecrets.externalSecret.secretPath .Values.extraEnvSecrets .Values.extraEnvConfigmaps }}
+          env:
+            {{- include "universal-chart.containerEnv" . | nindent 12 }}
+          {{- with include "universal-chart.containerEnvFrom" . | trim }}
           envFrom:
-            {{- if .Values.awsEnvSecrets.externalSecret.secretPath }}
-            - secretRef:
-                name: {{ .Values.awsEnvSecrets.env_secret_name }}
-            {{- end }}
-            {{- range .Values.extraEnvSecrets }}
-            - secretRef:
-                name: {{ . }}
-            {{- end }}
-            {{- range .Values.extraEnvConfigmaps }}
-            - configMapRef:
-                name: {{ . }}
-            {{- end }}
+            {{- . | nindent 12 }}
           {{- end }}
           {{- with .Values.securityContext }}
           securityContext:
@@ -130,11 +120,20 @@ spec:
           {{- with .Values.extraContainerProps }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+        {{- range $regularSidecars }}
+        {{- include "universal-chart.extraContainer" (dict "root" $ "container" .) | nindent 8 }}
+        {{- end }}
 
-      {{- with .Values.initContainers }}
-      {{- if get (first .) "image" }}
+      {{- if or $nativeSidecars $hasLegacyInit }}
       initContainers:
-        {{- range $i, $init := . }}
+        {{- /* Native sidecars render first so their startup probes gate the
+        legacy init containers; a migration that needs a proxy can rely on the
+        proxy being up before it runs. */}}
+        {{- range $nativeSidecars }}
+        {{- include "universal-chart.extraContainer" (dict "root" $ "container" . "native" true) | nindent 8 }}
+        {{- end }}
+        {{- if $hasLegacyInit }}
+        {{- range $i, $init := .Values.initContainers }}
         - name: init-{{ $.Chart.Name }}-{{ $i }}
           image: {{ $init.image }}
           {{- with $init.command }}
@@ -147,21 +146,11 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          env: *containerenv
-          {{- if or $.Values.awsEnvSecrets.externalSecret.secretPath $.Values.extraEnvSecrets $.Values.extraEnvConfigmaps }}
+          env:
+            {{- include "universal-chart.containerEnv" $ | nindent 12 }}
+          {{- with include "universal-chart.containerEnvFrom" $ | trim }}
           envFrom:
-            {{- if $.Values.awsEnvSecrets.externalSecret.secretPath }}
-            - secretRef:
-                name: {{ $.Values.awsEnvSecrets.env_secret_name }}
-            {{- end }}
-            {{- range $.Values.extraEnvSecrets }}
-            - secretRef:
-                name: {{ . }}
-            {{- end }}
-            {{- range $.Values.extraEnvConfigmaps }}
-            - configMapRef:
-                name: {{ . }}
-            {{- end }}
+            {{- . | nindent 12 }}
           {{- end }}
           {{- with $.Values.securityContext }}
           securityContext:
@@ -171,7 +160,7 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- end }}
+        {{- end }}
       {{- end }}
 
       {{- with .Values.volumes }}

--- a/charts/universal-chart/values.schema.json
+++ b/charts/universal-chart/values.schema.json
@@ -240,6 +240,290 @@
       "title": "extraContainerProps",
       "type": "object"
     },
+    "extraContainers": {
+      "description": "Additional long-running (sidecar) containers to run in the same pod as\nthe main container. Each entry needs a unique `name` and an `image` with\n`repository` plus exactly one of `tag` or `digest` (the same rule as the\nmain image). All containers share the chart-wide `image.pullPolicy`.\nBy default every entry inherits the main container's environment (env and\nenvFrom) and volume mounts; per-entry `env` and `volumeMounts` values are\nmerged on top and win on conflicts (env by name, mounts by mountPath). Set\n`inheritEnv: false` or `inheritVolumeMounts: false` to start from a clean\nslate instead — recommended for third-party images that don't need the\napp's secrets. An empty `securityContext` inherits the top-level\n`securityContext`; a non-empty one replaces it entirely. Set\n`nativeSidecar: true` to render the entry as a native sidecar (an init\ncontainer with `restartPolicy: Always`, Kubernetes 1.28+) that starts\nbefore init containers and the main container, and stops after them.\nContainer port names must be unique across the whole pod, so sidecar port\nnames cannot reuse `http` or names from `extraContainerPorts`. Use\n`extraContainerProps` for container fields the chart doesn't model, such\nas `lifecycle` or `workingDir`.",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "args": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "command": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "env": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "properties": {
+                    "valueFrom": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "fieldRef": {
+                              "properties": {
+                                "fieldPath": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "fieldRef"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "secretKeyRef": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "key"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "secretKeyRef"
+                          ]
+                        }
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "valueFrom"
+                  ],
+                  "type": "object"
+                }
+              ]
+            },
+            "required": [],
+            "type": "object"
+          },
+          "envFromConfigmaps": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "envFromSecrets": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "extraContainerProps": {
+            "additionalProperties": true,
+            "required": [],
+            "type": "object"
+          },
+          "image": {
+            "additionalProperties": false,
+            "oneOf": [
+              {
+                "properties": {
+                  "digest": {
+                    "type": "null"
+                  },
+                  "tag": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "tag"
+                ]
+              },
+              {
+                "properties": {
+                  "digest": {
+                    "type": "string"
+                  },
+                  "tag": {
+                    "type": "null"
+                  }
+                },
+                "required": [
+                  "digest"
+                ]
+              }
+            ],
+            "properties": {
+              "digest": {
+                "pattern": "^sha256:[a-f0-9]{64}$",
+                "required": [],
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "repository": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "tag": {
+                "minLength": 1,
+                "required": [],
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "repository"
+            ],
+            "type": "object"
+          },
+          "inheritEnv": {
+            "type": "boolean"
+          },
+          "inheritVolumeMounts": {
+            "type": "boolean"
+          },
+          "livenessProbe": {
+            "additionalProperties": true,
+            "required": [],
+            "type": "object"
+          },
+          "name": {
+            "minLength": 1,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+            "type": "string"
+          },
+          "nativeSidecar": {
+            "type": "boolean"
+          },
+          "ports": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "containerPort": {
+                  "maximum": 65535,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "name": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "protocol": {
+                  "enum": [
+                    "TCP",
+                    "UDP",
+                    "SCTP"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "containerPort"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "readinessProbe": {
+            "additionalProperties": true,
+            "required": [],
+            "type": "object"
+          },
+          "resources": {
+            "additionalProperties": false,
+            "properties": {
+              "limits": {
+                "additionalProperties": false,
+                "properties": {
+                  "cpu": {
+                    "type": "string"
+                  },
+                  "memory": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "requests": {
+                "additionalProperties": false,
+                "properties": {
+                  "cpu": {
+                    "type": "string"
+                  },
+                  "memory": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              }
+            },
+            "required": [],
+            "type": "object"
+          },
+          "securityContext": {
+            "additionalProperties": true,
+            "required": [],
+            "type": "object"
+          },
+          "startupProbe": {
+            "additionalProperties": true,
+            "required": [],
+            "type": "object"
+          },
+          "volumeMounts": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "mountPath": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "mountPath"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "image"
+        ],
+        "type": "object"
+      },
+      "title": "extraContainers",
+      "type": "array"
+    },
     "extraEnvConfigmaps": {
       "description": "extra configmaps to load into environment",
       "items": {

--- a/charts/universal-chart/values.yaml
+++ b/charts/universal-chart/values.yaml
@@ -229,6 +229,218 @@ extraEnvConfigmaps: []
 # -- extra ports to be exposed directly from pods (no service)
 extraContainerPorts: []
 
+# @schema
+# type: array
+# items:
+#   type: object
+#   additionalProperties: false
+#   required:
+#     - name
+#     - image
+#   properties:
+#     name:
+#       type: string
+#       minLength: 1
+#       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+#     image:
+#       type: object
+#       additionalProperties: false
+#       required:
+#         - repository
+#       properties:
+#         repository:
+#           type: string
+#           minLength: 1
+#         tag:
+#           type:
+#             - string
+#             - "null"
+#           minLength: 1
+#         digest:
+#           type:
+#             - string
+#             - "null"
+#           pattern: ^sha256:[a-f0-9]{64}$
+#       oneOf:
+#         - properties:
+#             tag:
+#               type: string
+#               minLength: 1
+#             digest:
+#               type: "null"
+#           required:
+#             - tag
+#         - properties:
+#             tag:
+#               type: "null"
+#             digest:
+#               type: string
+#           required:
+#             - digest
+#     command:
+#       type: array
+#       items:
+#         type: string
+#     args:
+#       type: array
+#       items:
+#         type: string
+#     env:
+#       type: object
+#       additionalProperties:
+#         anyOf:
+#           - type: string
+#           - type: object
+#             required:
+#               - valueFrom
+#             properties:
+#               valueFrom:
+#                 type: object
+#                 anyOf:
+#                   - properties:
+#                       fieldRef:
+#                         type: object
+#                         properties:
+#                           fieldPath:
+#                             type: string
+#                         required:
+#                           - fieldPath
+#                     required:
+#                       - fieldRef
+#                   - properties:
+#                       secretKeyRef:
+#                         type: object
+#                         properties:
+#                           name:
+#                             type: string
+#                           key:
+#                             type: string
+#                         required:
+#                           - name
+#                           - key
+#                     required:
+#                       - secretKeyRef
+#     inheritEnv:
+#       type: boolean
+#     envFromSecrets:
+#       type: array
+#       items:
+#         type: string
+#     envFromConfigmaps:
+#       type: array
+#       items:
+#         type: string
+#     securityContext:
+#       type: object
+#       additionalProperties: true
+#     ports:
+#       type: array
+#       items:
+#         type: object
+#         additionalProperties: false
+#         required:
+#           - name
+#           - containerPort
+#         properties:
+#           name:
+#             type: string
+#             minLength: 1
+#           containerPort:
+#             type: integer
+#             minimum: 1
+#             maximum: 65535
+#           protocol:
+#             type: string
+#             enum:
+#               - TCP
+#               - UDP
+#               - SCTP
+#     startupProbe:
+#       type: object
+#       additionalProperties: true
+#     livenessProbe:
+#       type: object
+#       additionalProperties: true
+#     readinessProbe:
+#       type: object
+#       additionalProperties: true
+#     resources:
+#       type: object
+#       additionalProperties: false
+#       properties:
+#         limits:
+#           type: object
+#           additionalProperties: false
+#           properties:
+#             cpu:
+#               type: string
+#             memory:
+#               type: string
+#         requests:
+#           type: object
+#           additionalProperties: false
+#           properties:
+#             cpu:
+#               type: string
+#             memory:
+#               type: string
+#     volumeMounts:
+#       type: array
+#       items:
+#         type: object
+#         additionalProperties: true
+#         required:
+#           - name
+#           - mountPath
+#         properties:
+#           name:
+#             type: string
+#             minLength: 1
+#           mountPath:
+#             type: string
+#             minLength: 1
+#     inheritVolumeMounts:
+#       type: boolean
+#     nativeSidecar:
+#       type: boolean
+#     extraContainerProps:
+#       type: object
+#       additionalProperties: true
+# @schema
+# -- Additional long-running (sidecar) containers to run in the same pod as
+# the main container. Each entry needs a unique `name` and an `image` with
+# `repository` plus exactly one of `tag` or `digest` (the same rule as the
+# main image). All containers share the chart-wide `image.pullPolicy`.
+# By default every entry inherits the main container's environment (env and
+# envFrom) and volume mounts; per-entry `env` and `volumeMounts` values are
+# merged on top and win on conflicts (env by name, mounts by mountPath). Set
+# `inheritEnv: false` or `inheritVolumeMounts: false` to start from a clean
+# slate instead — recommended for third-party images that don't need the
+# app's secrets. An empty `securityContext` inherits the top-level
+# `securityContext`; a non-empty one replaces it entirely. Set
+# `nativeSidecar: true` to render the entry as a native sidecar (an init
+# container with `restartPolicy: Always`, Kubernetes 1.28+) that starts
+# before init containers and the main container, and stops after them.
+# Container port names must be unique across the whole pod, so sidecar port
+# names cannot reuse `http` or names from `extraContainerPorts`. Use
+# `extraContainerProps` for container fields the chart doesn't model, such
+# as `lifecycle` or `workingDir`.
+extraContainers: []
+# - name: oauth2-proxy
+#   image:
+#     repository: quay.io/oauth2-proxy/oauth2-proxy
+#     tag: v7.6.0
+#   inheritEnv: false
+#   args:
+#     - --http-address=0.0.0.0:4180
+#   ports:
+#     - name: proxy
+#       containerPort: 4180
+#   resources:
+#     requests:
+#       cpu: 10m
+#       memory: 32Mi
+
 # This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
 serviceAccount:
   # Specifies whether a service account should be created (things may go poorly if you set this to false)

--- a/tests/fixtures/universal-chart/availability-preferred-values.golden.yaml
+++ b/tests/fixtures/universal-chart/availability-preferred-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/availability-strict-values.golden.yaml
+++ b/tests/fixtures/universal-chart/availability-strict-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/extra-containers-values.golden.yaml
+++ b/tests/fixtures/universal-chart/extra-containers-values.golden.yaml
@@ -64,15 +64,111 @@ spec:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"
+            - name: OVERRIDE_ME
+              value: "original"
+            - name: SHARED
+              value: "base"
           envFrom:
             - secretRef:
                 name: aws-env
+          securityContext:
+            runAsNonRoot: true
           image: "ghcr.io/example/app:1.2.3"
           imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 3000
               protocol: TCP
+          volumeMounts:
+            - mountPath: /scratch
+              name: shared-scratch
+        - name: worker
+          image: "ghcr.io/example/app:1.2.3"
+          imagePullPolicy: Always
+          command:
+            - pnpm
+          args:
+            - run
+            - worker
+          env:
+            - name: REDIS_ENABLED
+              value: "false"
+            - name: SHARED
+              value: base
+            - name: OVERRIDE_ME
+              value: overridden
+            - name: WORKER_ONLY
+              value: "yes"
+          envFrom:
+            - secretRef:
+                name: aws-env
+          securityContext:
+            runAsNonRoot: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          volumeMounts:
+            - mountPath: /scratch
+              name: shared-scratch
+        - name: oauth2-proxy
+          image: "quay.io/oauth2-proxy/oauth2-proxy@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+          imagePullPolicy: Always
+          envFrom:
+            - secretRef:
+                name: proxy-creds
+          securityContext:
+            runAsUser: 2000
+          ports:
+            - name: proxy
+              containerPort: 4180
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: proxy
+          volumeMounts:
+            - mountPath: /proxy-scratch
+              name: shared-scratch
+      initContainers:
+        - name: sql-proxy
+          image: "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.0"
+          imagePullPolicy: Always
+          restartPolicy: Always
+          securityContext:
+            runAsNonRoot: true
+          startupProbe:
+            httpGet:
+              path: /startup
+              port: 9801
+          volumeMounts:
+            - mountPath: /scratch
+              name: shared-scratch
+          workingDir: /tmp
+        - name: init-universal-chart-0
+          image: amazon/aws-cli:latest
+          command:
+            - s3
+            - sync
+          volumeMounts:
+            - mountPath: /scratch
+              name: shared-scratch
+          env:
+            # placeholder var so we can always make an env list
+            - name: REDIS_ENABLED
+              value: "false"
+            - name: OVERRIDE_ME
+              value: "original"
+            - name: SHARED
+              value: "base"
+          envFrom:
+            - secretRef:
+                name: aws-env
+          securityContext:
+            runAsNonRoot: true
+      volumes:
+        - emptyDir: {}
+          name: shared-scratch
       topologySpreadConstraints:
         - labelSelector:
             matchLabels:
@@ -100,5 +196,5 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
-      key: test/stage/secret
+      key: /example/app
       metadataPolicy: None

--- a/tests/fixtures/universal-chart/extra-containers-values.yaml
+++ b/tests/fixtures/universal-chart/extra-containers-values.yaml
@@ -1,0 +1,71 @@
+image:
+  repository: ghcr.io/example/app
+  tag: "1.2.3"
+extraEnvVars:
+  SHARED: base
+  OVERRIDE_ME: original
+awsEnvSecrets:
+  externalSecret:
+    secretPath: /example/app
+securityContext:
+  runAsNonRoot: true
+volumes:
+  - name: shared-scratch
+    emptyDir: {}
+volumeMounts:
+  - name: shared-scratch
+    mountPath: /scratch
+initContainers:
+  - image: amazon/aws-cli:latest
+    command:
+      - s3
+      - sync
+extraContainers:
+  # same-image companion process: inherits everything, overrides one env var
+  - name: worker
+    image:
+      repository: ghcr.io/example/app
+      tag: "1.2.3"
+    command: ["pnpm"]
+    args: ["run", "worker"]
+    env:
+      OVERRIDE_ME: overridden
+      WORKER_ONLY: "yes"
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+  # third-party helper: isolated from the app's env and mounts
+  - name: oauth2-proxy
+    image:
+      repository: quay.io/oauth2-proxy/oauth2-proxy
+      digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    inheritEnv: false
+    inheritVolumeMounts: false
+    envFromSecrets:
+      - proxy-creds
+    securityContext:
+      runAsUser: 2000
+    ports:
+      - name: proxy
+        containerPort: 4180
+    readinessProbe:
+      httpGet:
+        path: /ping
+        port: proxy
+    volumeMounts:
+      - name: shared-scratch
+        mountPath: /proxy-scratch
+  # native sidecar: starts before init containers and the main container
+  - name: sql-proxy
+    nativeSidecar: true
+    image:
+      repository: gcr.io/cloud-sql-connectors/cloud-sql-proxy
+      tag: "2.14.0"
+    inheritEnv: false
+    startupProbe:
+      httpGet:
+        path: /startup
+        port: 9801
+    extraContainerProps:
+      workingDir: /tmp

--- a/tests/fixtures/universal-chart/hpa-values.golden.yaml
+++ b/tests/fixtures/universal-chart/hpa-values.golden.yaml
@@ -59,7 +59,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/image-digest-values.golden.yaml
+++ b/tests/fixtures/universal-chart/image-digest-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/ingress-values.golden.yaml
+++ b/tests/fixtures/universal-chart/ingress-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/init-container-values.golden.yaml
+++ b/tests/fixtures/universal-chart/init-container-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"
@@ -80,7 +80,10 @@ spec:
             - --no-progress
             - s3://{{ .s3_bucket }}/{{ .number }}
             - /app
-          env: *containerenv
+          env:
+            # placeholder var so we can always make an env list
+            - name: REDIS_ENABLED
+              value: "false"
       topologySpreadConstraints:
         - labelSelector:
             matchLabels:

--- a/tests/fixtures/universal-chart/metrics-block-disabled-values.golden.yaml
+++ b/tests/fixtures/universal-chart/metrics-block-disabled-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/minimal-values.golden.yaml
+++ b/tests/fixtures/universal-chart/minimal-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/pdb-max-unavailable-values.golden.yaml
+++ b/tests/fixtures/universal-chart/pdb-max-unavailable-values.golden.yaml
@@ -78,7 +78,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/pdb-values.golden.yaml
+++ b/tests/fixtures/universal-chart/pdb-values.golden.yaml
@@ -79,7 +79,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/probe-http-values.golden.yaml
+++ b/tests/fixtures/universal-chart/probe-http-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/prometheusrule-groups-values.golden.yaml
+++ b/tests/fixtures/universal-chart/prometheusrule-groups-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/prometheusrule-values.golden.yaml
+++ b/tests/fixtures/universal-chart/prometheusrule-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/reloader-values.golden.yaml
+++ b/tests/fixtures/universal-chart/reloader-values.golden.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/s3-values.golden.yaml
+++ b/tests/fixtures/universal-chart/s3-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/service-extra-ports-values.golden.yaml
+++ b/tests/fixtures/universal-chart/service-extra-ports-values.golden.yaml
@@ -70,7 +70,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/servicemonitor-alt-port-values.golden.yaml
+++ b/tests/fixtures/universal-chart/servicemonitor-alt-port-values.golden.yaml
@@ -81,7 +81,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/servicemonitor-values.golden.yaml
+++ b/tests/fixtures/universal-chart/servicemonitor-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/topology-spread-azs-values.golden.yaml
+++ b/tests/fixtures/universal-chart/topology-spread-azs-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/topology-spread-both-values.golden.yaml
+++ b/tests/fixtures/universal-chart/topology-spread-both-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/fixtures/universal-chart/topology-spread-spot-values.golden.yaml
+++ b/tests/fixtures/universal-chart/topology-spread-spot-values.golden.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: universal-chart
       containers:
         - name: universal-chart
-          env: &containerenv
+          env:
             # placeholder var so we can always make an env list
             - name: REDIS_ENABLED
               value: "false"

--- a/tests/test_universal_chart_extra_containers.py
+++ b/tests/test_universal_chart_extra_containers.py
@@ -1,0 +1,368 @@
+"""Extra (sidecar) container tests for universal-chart."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from .conftest import HelmTemplateError
+from .chart_test_utils import get_manifest
+from .universal_chart_test_utils import render_manifests
+
+SIDECAR_IMAGE = {"repository": "ghcr.io/example/sidecar", "tag": "9.9.9"}
+
+
+def _sidecar(**overrides: Any) -> dict[str, Any]:
+    """Return a minimal valid extraContainers entry with overrides."""
+
+    entry: dict[str, Any] = {"name": "sidecar", "image": dict(SIDECAR_IMAGE)}
+    entry.update(overrides)
+    return entry
+
+
+def _pod_spec(manifests: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return the Deployment pod spec."""
+
+    deployment = get_manifest(manifests, "Deployment")
+    return deployment["spec"]["template"]["spec"]
+
+
+def _container(
+    manifests: list[dict[str, Any]],
+    name: str,
+    *,
+    init: bool = False,
+) -> dict[str, Any]:
+    """Return one container from the pod spec by name."""
+
+    key = "initContainers" if init else "containers"
+    containers = _pod_spec(manifests).get(key, [])
+    for container in containers:
+        if container["name"] == name:
+            return container
+    raise AssertionError(f"Container {name} not found in {key}")
+
+
+def test_sidecar_renders_after_main_container(helm_runner) -> None:
+    """Keep the main container first so kubectl defaults stay stable."""
+
+    manifests = render_manifests(
+        helm_runner,
+        values={"extraContainers": [_sidecar()]},
+    )
+    containers = _pod_spec(manifests)["containers"]
+
+    assert [c["name"] for c in containers] == ["universal-chart", "sidecar"]
+    assert containers[1]["image"] == "ghcr.io/example/sidecar:9.9.9"
+
+
+def test_sidecar_uses_chart_wide_pull_policy(helm_runner) -> None:
+    """Apply the shared image.pullPolicy to sidecar containers."""
+
+    manifests = render_manifests(
+        helm_runner,
+        values={
+            "image.pullPolicy": "IfNotPresent",
+            "extraContainers": [_sidecar()],
+        },
+    )
+
+    sidecar = _container(manifests, "sidecar")
+    assert sidecar["imagePullPolicy"] == "IfNotPresent"
+
+
+def test_sidecar_image_renders_digest_reference(helm_runner) -> None:
+    """Render repository@digest when the entry selects a digest."""
+
+    digest = "sha256:" + "ab" * 32
+    manifests = render_manifests(
+        helm_runner,
+        values={
+            "extraContainers": [
+                _sidecar(
+                    image={
+                        "repository": "ghcr.io/example/sidecar",
+                        "digest": digest,
+                    }
+                )
+            ]
+        },
+    )
+
+    sidecar = _container(manifests, "sidecar")
+    assert sidecar["image"] == f"ghcr.io/example/sidecar@{digest}"
+
+
+def test_sidecar_inherits_env_and_env_from_by_default(helm_runner) -> None:
+    """Copy the main container environment into inheriting sidecars."""
+
+    manifests = render_manifests(
+        helm_runner,
+        values={
+            "extraEnvVars": {"SHARED": "base"},
+            "awsEnvSecrets.externalSecret.secretPath": "/example/app",
+            "extraContainers": [_sidecar()],
+        },
+    )
+
+    sidecar = _container(manifests, "sidecar")
+    env = {entry["name"]: entry.get("value") for entry in sidecar["env"]}
+    assert env["SHARED"] == "base"
+    assert env["REDIS_ENABLED"] == "false"
+    assert {"secretRef": {"name": "aws-env"}} in sidecar["envFrom"]
+
+
+def test_sidecar_env_merges_and_overrides_inherited_values(
+    helm_runner,
+) -> None:
+    """Merge sidecar env on top of the inherited environment."""
+
+    manifests = render_manifests(
+        helm_runner,
+        values={
+            "extraEnvVars": {"SHARED": "base", "OVERRIDE_ME": "original"},
+            "extraContainers": [
+                _sidecar(
+                    env={"OVERRIDE_ME": "overridden", "OWN_VAR": "yes"},
+                )
+            ],
+        },
+    )
+
+    sidecar = _container(manifests, "sidecar")
+    env = {entry["name"]: entry.get("value") for entry in sidecar["env"]}
+    assert env["SHARED"] == "base"
+    assert env["OVERRIDE_ME"] == "overridden"
+    assert env["OWN_VAR"] == "yes"
+    names = [entry["name"] for entry in sidecar["env"]]
+    assert names.count("OVERRIDE_ME") == 1
+
+
+def test_sidecar_inherit_env_false_isolates_environment(helm_runner) -> None:
+    """Drop the inherited env and envFrom when inheritEnv is false."""
+
+    manifests = render_manifests(
+        helm_runner,
+        values={
+            "extraEnvVars": {"SHARED": "base"},
+            "awsEnvSecrets.externalSecret.secretPath": "/example/app",
+            "extraContainers": [
+                _sidecar(
+                    inheritEnv=False,
+                    env={"OWN_VAR": "yes"},
+                    envFromSecrets=["own-secret"],
+                )
+            ],
+        },
+    )
+
+    sidecar = _container(manifests, "sidecar")
+    env = {entry["name"]: entry.get("value") for entry in sidecar["env"]}
+    assert env == {"OWN_VAR": "yes"}
+    assert sidecar["envFrom"] == [{"secretRef": {"name": "own-secret"}}]
+
+
+def test_sidecar_volume_mounts_merge_and_override_by_path(
+    helm_runner,
+) -> None:
+    """Merge sidecar mounts over inherited mounts, keyed by mountPath."""
+
+    manifests = render_manifests(
+        helm_runner,
+        values={
+            "volumeMounts": [
+                {"name": "shared", "mountPath": "/scratch"},
+                {"name": "shared", "mountPath": "/config"},
+            ],
+            "extraContainers": [
+                _sidecar(
+                    volumeMounts=[
+                        {
+                            "name": "shared",
+                            "mountPath": "/config",
+                            "readOnly": True,
+                        }
+                    ],
+                )
+            ],
+        },
+    )
+
+    sidecar = _container(manifests, "sidecar")
+    mounts = {m["mountPath"]: m for m in sidecar["volumeMounts"]}
+    assert set(mounts) == {"/scratch", "/config"}
+    assert mounts["/config"]["readOnly"] is True
+
+
+def test_sidecar_inherit_volume_mounts_false_uses_own_mounts(
+    helm_runner,
+) -> None:
+    """Drop inherited mounts when inheritVolumeMounts is false."""
+
+    manifests = render_manifests(
+        helm_runner,
+        values={
+            "volumeMounts": [{"name": "shared", "mountPath": "/scratch"}],
+            "extraContainers": [
+                _sidecar(
+                    inheritVolumeMounts=False,
+                    volumeMounts=[{"name": "own", "mountPath": "/own"}],
+                )
+            ],
+        },
+    )
+
+    sidecar = _container(manifests, "sidecar")
+    assert sidecar["volumeMounts"] == [{"name": "own", "mountPath": "/own"}]
+
+
+def test_sidecar_security_context_inherits_then_replaces(helm_runner) -> None:
+    """Inherit the top-level securityContext until the entry sets one."""
+
+    values: dict[str, Any] = {
+        "securityContext": {"runAsNonRoot": True, "runAsUser": 1000},
+        "extraContainers": [
+            _sidecar(),
+            _sidecar(name="custom", securityContext={"runAsUser": 2000}),
+        ],
+    }
+    manifests = render_manifests(helm_runner, values=values)
+
+    inherited = _container(manifests, "sidecar")
+    replaced = _container(manifests, "custom")
+    assert inherited["securityContext"] == {
+        "runAsNonRoot": True,
+        "runAsUser": 1000,
+    }
+    assert replaced["securityContext"] == {"runAsUser": 2000}
+
+
+def test_sidecar_probes_and_ports_render(helm_runner) -> None:
+    """Render per-sidecar probes and ports."""
+
+    manifests = render_manifests(
+        helm_runner,
+        values={
+            "extraContainers": [
+                _sidecar(
+                    ports=[{"name": "metrics", "containerPort": 9090}],
+                    readinessProbe={
+                        "httpGet": {"path": "/ready", "port": "metrics"}
+                    },
+                    livenessProbe={
+                        "httpGet": {"path": "/live", "port": "metrics"}
+                    },
+                )
+            ]
+        },
+    )
+
+    sidecar = _container(manifests, "sidecar")
+    assert sidecar["ports"] == [
+        {"name": "metrics", "containerPort": 9090, "protocol": "TCP"}
+    ]
+    assert sidecar["readinessProbe"]["httpGet"]["path"] == "/ready"
+    assert sidecar["livenessProbe"]["httpGet"]["path"] == "/live"
+
+
+def test_native_sidecar_renders_as_restarting_init_container(
+    helm_runner,
+) -> None:
+    """Render nativeSidecar entries as initContainers with restartPolicy."""
+
+    manifests = render_manifests(
+        helm_runner,
+        values={"extraContainers": [_sidecar(nativeSidecar=True)]},
+    )
+    pod_spec = _pod_spec(manifests)
+
+    assert [c["name"] for c in pod_spec["containers"]] == ["universal-chart"]
+    sidecar = _container(manifests, "sidecar", init=True)
+    assert sidecar["restartPolicy"] == "Always"
+
+
+def test_native_sidecar_precedes_legacy_init_containers(helm_runner) -> None:
+    """Order native sidecars before legacy init containers."""
+
+    manifests = render_manifests(
+        helm_runner,
+        values={
+            "initContainers": [{"image": "amazon/aws-cli:latest"}],
+            "extraContainers": [_sidecar(nativeSidecar=True)],
+        },
+    )
+    init_names = [
+        c["name"] for c in _pod_spec(manifests)["initContainers"]
+    ]
+
+    assert init_names == ["sidecar", "init-universal-chart-0"]
+
+
+def test_sidecar_extra_container_props_pass_through(helm_runner) -> None:
+    """Merge extraContainerProps keys into the container spec."""
+
+    manifests = render_manifests(
+        helm_runner,
+        values={
+            "extraContainers": [
+                _sidecar(extraContainerProps={"workingDir": "/srv"})
+            ]
+        },
+    )
+
+    sidecar = _container(manifests, "sidecar")
+    assert sidecar["workingDir"] == "/srv"
+
+
+@pytest.mark.parametrize(
+    "extra_containers",
+    [
+        pytest.param([_sidecar(name="universal-chart")], id="main-container"),
+        pytest.param([_sidecar(), _sidecar()], id="duplicate-sidecars"),
+        pytest.param(
+            [_sidecar(name="init-universal-chart-0", nativeSidecar=True)],
+            id="generated-init-name",
+        ),
+    ],
+)
+def test_container_name_collisions_fail(
+    helm_runner,
+    extra_containers: list[dict[str, Any]],
+) -> None:
+    """Fail rendering when container names collide."""
+
+    values: dict[str, Any] = {"extraContainers": extra_containers}
+    if extra_containers[0]["name"].startswith("init-"):
+        values["initContainers"] = [{"image": "amazon/aws-cli:latest"}]
+
+    with pytest.raises(HelmTemplateError):
+        render_manifests(helm_runner, values=values)
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        pytest.param(_sidecar(image={"repository": "x"}), id="no-tag"),
+        pytest.param(
+            _sidecar(
+                image={
+                    "repository": "x",
+                    "tag": "1",
+                    "digest": "sha256:" + "ab" * 32,
+                }
+            ),
+            id="tag-and-digest",
+        ),
+        pytest.param(_sidecar(readinesProbe={}), id="typo-key"),
+        pytest.param({"image": dict(SIDECAR_IMAGE)}, id="missing-name"),
+    ],
+)
+def test_schema_rejects_invalid_entries(
+    helm_runner,
+    entry: dict[str, Any],
+) -> None:
+    """Reject malformed extraContainers entries at render time."""
+
+    with pytest.raises(HelmTemplateError):
+        render_manifests(helm_runner, values={"extraContainers": [entry]})

--- a/tests/test_universal_chart_extra_containers.py
+++ b/tests/test_universal_chart_extra_containers.py
@@ -6,8 +6,8 @@ from typing import Any
 
 import pytest
 
-from .conftest import HelmTemplateError
 from .chart_test_utils import get_manifest
+from .conftest import HelmTemplateError
 from .universal_chart_test_utils import render_manifests
 
 SIDECAR_IMAGE = {"repository": "ghcr.io/example/sidecar", "tag": "9.9.9"}
@@ -292,9 +292,7 @@ def test_native_sidecar_precedes_legacy_init_containers(helm_runner) -> None:
             "extraContainers": [_sidecar(nativeSidecar=True)],
         },
     )
-    init_names = [
-        c["name"] for c in _pod_spec(manifests)["initContainers"]
-    ]
+    init_names = [c["name"] for c in _pod_spec(manifests)["initContainers"]]
 
     assert init_names == ["sidecar", "init-universal-chart-0"]
 


### PR DESCRIPTION
Add an `extraContainers` value for running additional containers in the same pod as the main container: same-image companion processes, third-party helpers such as proxies and exporters, and native sidecars.

Each entry takes a unique `name` and an `image` with `repository` plus exactly one of `tag` or `digest`, validated by the values schema. Entries inherit the main container's env, envFrom, and volumeMounts by default; per-entry values merge on top and win on conflict (env by name, mounts by mountPath), and `inheritEnv`/`inheritVolumeMounts` opt out entirely. An empty `securityContext` inherits the top-level one; a non-empty one replaces it. `nativeSidecar` renders the entry as an init container with `restartPolicy: Always` (Kubernetes 1.28+), placed ahead of legacy init containers so its startup probe gates them. Rendering fails fast on container name collisions.

The shared env and envFrom blocks move from a YAML anchor in the deployment template to named helpers so sidecars can merge onto them; init containers now use the same helpers with unchanged output. Golden files are regenerated for the anchor removal.

Docs cover the inheritance model, readiness-probe blast radius, the HPA utilization-dilution caveat (with a `ContainerResource` TODO in the HPA helper), the native-sidecar version requirement, and wiring a sidecar port through `service.extraPorts` and `serviceMonitor.alternatePort`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUTdAT9Rsn4XZwpnyMf8En